### PR TITLE
Feat/#7 학생회 회원가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,10 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 
+    // mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/campus/campus/CampusApplication.java
+++ b/src/main/java/com/campus/campus/CampusApplication.java
@@ -2,8 +2,10 @@ package com.campus.campus;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class CampusApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/campus/campus/domain/council/application/dto/request/StudentCouncilLoginRequest.java
+++ b/src/main/java/com/campus/campus/domain/council/application/dto/request/StudentCouncilLoginRequest.java
@@ -1,0 +1,15 @@
+package com.campus.campus.domain.council.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record StudentCouncilLoginRequest(
+	@Schema(description = "회원가입할 이메일(id)", example = "campus@campus.com")
+	@NotBlank
+	String loginId,
+
+	@Schema(description = "비밀번호", example = "qwerqwer")
+	@NotBlank
+	String password
+) {
+}

--- a/src/main/java/com/campus/campus/domain/council/application/dto/request/StudentCouncilSignUpRequest.java
+++ b/src/main/java/com/campus/campus/domain/council/application/dto/request/StudentCouncilSignUpRequest.java
@@ -7,13 +7,17 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record StudentCouncilSignUpRequest(
-	@Schema(description = "회원가입할 이메일(id)", example = "campus@campus.com")
+	@Schema(description = "회원가입 id", example = "dede1234")
 	@NotBlank
 	String loginId,
 
 	@Schema(description = "비밀번호", example = "qwerqwer")
 	@NotBlank
 	String password,
+
+	@Schema(description = "인증 이메일", example = "campus@campus.com")
+	@NotBlank
+	String email,
 
 	@Schema(description = "학생회 종류", example = "SCHOOL_COUNCIL")
 	@NotNull

--- a/src/main/java/com/campus/campus/domain/council/application/dto/request/StudentCouncilSignUpRequest.java
+++ b/src/main/java/com/campus/campus/domain/council/application/dto/request/StudentCouncilSignUpRequest.java
@@ -1,0 +1,32 @@
+package com.campus.campus.domain.council.application.dto.request;
+
+import com.campus.campus.domain.council.domain.entity.CouncilType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record StudentCouncilSignUpRequest(
+	@Schema(description = "회원가입할 이메일(id)", example = "campus@campus.com")
+	@NotBlank
+	String loginId,
+
+	@Schema(description = "비밀번호", example = "qwerqwer")
+	@NotBlank
+	String password,
+
+	@Schema(description = "학생회 종류", example = "SCHOOL_COUNCIL")
+	@NotNull
+	CouncilType councilType,
+
+	@Schema(description = "학교 id", example = "1")
+	@NotNull
+	Long schoolId,
+
+	@Schema(description = "단과대 id", example = "1")
+	Long collegeId,
+
+	@Schema(description = "학과 id", example = "1")
+	Long majorId
+) {
+}

--- a/src/main/java/com/campus/campus/domain/council/application/dto/response/StudentCouncilLoginResponse.java
+++ b/src/main/java/com/campus/campus/domain/council/application/dto/response/StudentCouncilLoginResponse.java
@@ -16,8 +16,11 @@ public record StudentCouncilLoginResponse(
 	@Schema(description = "학생회 ID", example = "1")
 	Long councilId,
 
-	@Schema(description = "로그인 이메일", example = "council@gachon.ac.kr")
+	@Schema(description = "로그인 id", example = "dede1234")
 	String loginId,
+
+	@Schema(description = "인증 이메일", example = "campus@campus.com")
+	String email,
 
 	@Schema(description = "학생회 타입", example = "SCHOOL_COUNCIL")
 	CouncilType councilType,

--- a/src/main/java/com/campus/campus/domain/council/application/dto/response/StudentCouncilLoginResponse.java
+++ b/src/main/java/com/campus/campus/domain/council/application/dto/response/StudentCouncilLoginResponse.java
@@ -1,0 +1,34 @@
+package com.campus.campus.domain.council.application.dto.response;
+
+import com.campus.campus.domain.council.domain.entity.CouncilType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record StudentCouncilLoginResponse(
+	@Schema(description = "access token", example = "랜덤 accessToken")
+	String accessToken,
+
+	@Schema(description = "refresh token", example = "랜덤 refreshToken")
+	String refreshToken,
+
+	@Schema(description = "학생회 ID", example = "1")
+	Long councilId,
+
+	@Schema(description = "로그인 이메일", example = "council@gachon.ac.kr")
+	String loginId,
+
+	@Schema(description = "학생회 타입", example = "SCHOOL_COUNCIL")
+	CouncilType councilType,
+
+	@Schema(description = "학교 이름", example = "가천대학교")
+	String schoolName,
+
+	@Schema(description = "단과대 이름 (없으면 null)", example = "IT융합대학")
+	String collegeName,
+
+	@Schema(description = "학과 이름 (없으면 null)", example = "컴퓨터공학과")
+	String majorName
+) {
+}

--- a/src/main/java/com/campus/campus/domain/council/application/exception/EmailAlreadyExistsException.java
+++ b/src/main/java/com/campus/campus/domain/council/application/exception/EmailAlreadyExistsException.java
@@ -1,0 +1,9 @@
+package com.campus.campus.domain.council.application.exception;
+
+import com.campus.campus.global.common.exception.ApplicationException;
+
+public class EmailAlreadyExistsException extends ApplicationException {
+	public EmailAlreadyExistsException() {
+		super(ErrorCode.EMAIL_ALREADY_EXISTS);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/council/application/exception/ErrorCode.java
+++ b/src/main/java/com/campus/campus/domain/council/application/exception/ErrorCode.java
@@ -13,8 +13,8 @@ public enum ErrorCode implements ErrorCodeInterface {
 	COUNCIL_NOT_FOUND(2300, HttpStatus.NOT_FOUND, "해당 학생회가 존재하지 않습니다."),
 	LOGIN_ID_ALREADY_EXISTS(2301, HttpStatus.CONFLICT, "이미 가입된 아이디입니다."),
 	EMAIL_ALREADY_EXISTS(2302, HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
-	INVALID_COUNCIL_SCOPE(2302, HttpStatus.BAD_REQUEST, "학생회 범위에 맞지 않습니다."),
-	PASSWORD_NOT_COLLECT(2303, HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다.");
+	INVALID_COUNCIL_SCOPE(2303, HttpStatus.BAD_REQUEST, "학생회 범위에 맞지 않습니다."),
+	PASSWORD_NOT_CORRECT(2304, HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다.");
 
 	private final int code;
 	private final HttpStatus status;

--- a/src/main/java/com/campus/campus/domain/council/application/exception/ErrorCode.java
+++ b/src/main/java/com/campus/campus/domain/council/application/exception/ErrorCode.java
@@ -11,7 +11,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode implements ErrorCodeInterface {
 	COUNCIL_NOT_FOUND(2300, HttpStatus.NOT_FOUND, "해당 학생회가 존재하지 않습니다."),
-	LOGIN_ID_ALREADY_EXISTS(2301, HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
+	LOGIN_ID_ALREADY_EXISTS(2301, HttpStatus.CONFLICT, "이미 가입된 아이디입니다."),
+	EMAIL_ALREADY_EXISTS(2302, HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
 	INVALID_COUNCIL_SCOPE(2302, HttpStatus.BAD_REQUEST, "학생회 범위에 맞지 않습니다."),
 	PASSWORD_NOT_COLLECT(2303, HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다.");
 

--- a/src/main/java/com/campus/campus/domain/council/application/exception/ErrorCode.java
+++ b/src/main/java/com/campus/campus/domain/council/application/exception/ErrorCode.java
@@ -1,0 +1,21 @@
+package com.campus.campus.domain.council.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.campus.campus.global.common.exception.ErrorCodeInterface;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode implements ErrorCodeInterface {
+	COUNCIL_NOT_FOUND(2300, HttpStatus.NOT_FOUND, "해당 학생회가 존재하지 않습니다."),
+	LOGIN_ID_ALREADY_EXISTS(2301, HttpStatus.CONFLICT, "이미 가입된 이메일입니다."),
+	INVALID_COUNCIL_SCOPE(2302, HttpStatus.BAD_REQUEST, "학생회 범위에 맞지 않습니다."),
+	PASSWORD_NOT_COLLECT(2303, HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다.");
+
+	private final int code;
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/com/campus/campus/domain/council/application/exception/InvalidCouncilScopeException.java
+++ b/src/main/java/com/campus/campus/domain/council/application/exception/InvalidCouncilScopeException.java
@@ -1,0 +1,9 @@
+package com.campus.campus.domain.council.application.exception;
+
+import com.campus.campus.global.common.exception.ApplicationException;
+
+public class InvalidCouncilScopeException extends ApplicationException {
+	public InvalidCouncilScopeException() {
+		super(ErrorCode.INVALID_COUNCIL_SCOPE);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/council/application/exception/LoginIdAlreadyExistsException.java
+++ b/src/main/java/com/campus/campus/domain/council/application/exception/LoginIdAlreadyExistsException.java
@@ -1,0 +1,9 @@
+package com.campus.campus.domain.council.application.exception;
+
+import com.campus.campus.global.common.exception.ApplicationException;
+
+public class LoginIdAlreadyExistsException extends ApplicationException {
+	public LoginIdAlreadyExistsException() {
+		super(ErrorCode.LOGIN_ID_ALREADY_EXISTS);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/council/application/exception/PasswordNotCollectException.java
+++ b/src/main/java/com/campus/campus/domain/council/application/exception/PasswordNotCollectException.java
@@ -1,9 +1,0 @@
-package com.campus.campus.domain.council.application.exception;
-
-import com.campus.campus.global.common.exception.ApplicationException;
-
-public class PasswordNotCollectException extends ApplicationException {
-	public PasswordNotCollectException() {
-		super(ErrorCode.PASSWORD_NOT_COLLECT);
-	}
-}

--- a/src/main/java/com/campus/campus/domain/council/application/exception/PasswordNotCollectException.java
+++ b/src/main/java/com/campus/campus/domain/council/application/exception/PasswordNotCollectException.java
@@ -1,0 +1,9 @@
+package com.campus.campus.domain.council.application.exception;
+
+import com.campus.campus.global.common.exception.ApplicationException;
+
+public class PasswordNotCollectException extends ApplicationException {
+	public PasswordNotCollectException() {
+		super(ErrorCode.PASSWORD_NOT_COLLECT);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/council/application/exception/PasswordNotCorrectException.java
+++ b/src/main/java/com/campus/campus/domain/council/application/exception/PasswordNotCorrectException.java
@@ -1,0 +1,9 @@
+package com.campus.campus.domain.council.application.exception;
+
+import com.campus.campus.global.common.exception.ApplicationException;
+
+public class PasswordNotCorrectException extends ApplicationException {
+	public PasswordNotCorrectException() {
+		super(ErrorCode.PASSWORD_NOT_CORRECT);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/council/application/exception/StudentCouncilNotFoundException.java
+++ b/src/main/java/com/campus/campus/domain/council/application/exception/StudentCouncilNotFoundException.java
@@ -1,0 +1,9 @@
+package com.campus.campus.domain.council.application.exception;
+
+import com.campus.campus.global.common.exception.ApplicationException;
+
+public class StudentCouncilNotFoundException extends ApplicationException {
+	public StudentCouncilNotFoundException() {
+		super(ErrorCode.COUNCIL_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/council/application/mapper/StudentCouncilLoginMapper.java
+++ b/src/main/java/com/campus/campus/domain/council/application/mapper/StudentCouncilLoginMapper.java
@@ -24,6 +24,7 @@ public class StudentCouncilLoginMapper {
 		return StudentCouncil.builder()
 			.loginId(studentCouncilSignUpRequest.loginId())
 			.password(encodedPassword)
+			.email(studentCouncilSignUpRequest.email())
 			.councilType(studentCouncilSignUpRequest.councilType())
 			.school(school)
 			.college(college)
@@ -38,6 +39,7 @@ public class StudentCouncilLoginMapper {
 			refreshToken,
 			studentCouncil.getId(),
 			studentCouncil.getLoginId(),
+			studentCouncil.getEmail(),
 			studentCouncil.getCouncilType(),
 			studentCouncil.getSchool().getSchoolName(),
 			studentCouncil.getCollege() != null ? studentCouncil.getCollege().getCollegeName() : null,

--- a/src/main/java/com/campus/campus/domain/council/application/mapper/StudentCouncilLoginMapper.java
+++ b/src/main/java/com/campus/campus/domain/council/application/mapper/StudentCouncilLoginMapper.java
@@ -1,0 +1,47 @@
+package com.campus.campus.domain.council.application.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.campus.campus.domain.council.application.dto.request.StudentCouncilSignUpRequest;
+import com.campus.campus.domain.council.application.dto.response.StudentCouncilLoginResponse;
+import com.campus.campus.domain.council.domain.entity.StudentCouncil;
+import com.campus.campus.domain.school.domain.entity.College;
+import com.campus.campus.domain.school.domain.entity.Major;
+import com.campus.campus.domain.school.domain.entity.School;
+import com.campus.campus.global.config.SecurityConfig;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class StudentCouncilLoginMapper {
+	private final SecurityConfig securityConfig;
+
+	public StudentCouncil createStudentCouncil(StudentCouncilSignUpRequest studentCouncilSignUpRequest, School school,
+		College college, Major major) {
+		String encodedPassword = securityConfig.passwordEncoder().encode(studentCouncilSignUpRequest.password());
+
+		return StudentCouncil.builder()
+			.loginId(studentCouncilSignUpRequest.loginId())
+			.password(encodedPassword)
+			.councilType(studentCouncilSignUpRequest.councilType())
+			.school(school)
+			.college(college)
+			.major(major)
+			.build();
+	}
+
+	public StudentCouncilLoginResponse toStudentCouncilLoginResponse(StudentCouncil studentCouncil, String accessToken,
+		String refreshToken) {
+		return new StudentCouncilLoginResponse(
+			accessToken,
+			refreshToken,
+			studentCouncil.getId(),
+			studentCouncil.getLoginId(),
+			studentCouncil.getCouncilType(),
+			studentCouncil.getSchool().getSchoolName(),
+			studentCouncil.getCollege() != null ? studentCouncil.getCollege().getCollegeName() : null,
+			studentCouncil.getMajor() != null ? studentCouncil.getMajor().getMajorName() : null
+		);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/council/application/service/CouncilLoginService.java
+++ b/src/main/java/com/campus/campus/domain/council/application/service/CouncilLoginService.java
@@ -10,7 +10,7 @@ import com.campus.campus.domain.council.application.dto.response.StudentCouncilL
 import com.campus.campus.domain.council.application.exception.EmailAlreadyExistsException;
 import com.campus.campus.domain.council.application.exception.InvalidCouncilScopeException;
 import com.campus.campus.domain.council.application.exception.LoginIdAlreadyExistsException;
-import com.campus.campus.domain.council.application.exception.PasswordNotCollectException;
+import com.campus.campus.domain.council.application.exception.PasswordNotCorrectException;
 import com.campus.campus.domain.council.application.exception.StudentCouncilNotFoundException;
 import com.campus.campus.domain.council.application.mapper.StudentCouncilLoginMapper;
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
@@ -76,7 +76,7 @@ public class CouncilLoginService {
 			.orElseThrow(StudentCouncilNotFoundException::new);
 
 		if (!passwordEncoder.matches(studentCouncilLoginRequest.password(), studentCouncil.getPassword())) {
-			throw new PasswordNotCollectException();
+			throw new PasswordNotCorrectException();
 		}
 
 		String accessToken = jwtProvider.createCouncilAccessToken(studentCouncil.getId());

--- a/src/main/java/com/campus/campus/domain/council/application/service/CouncilLoginService.java
+++ b/src/main/java/com/campus/campus/domain/council/application/service/CouncilLoginService.java
@@ -1,0 +1,133 @@
+package com.campus.campus.domain.council.application.service;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.campus.campus.domain.council.application.dto.request.StudentCouncilLoginRequest;
+import com.campus.campus.domain.council.application.dto.request.StudentCouncilSignUpRequest;
+import com.campus.campus.domain.council.application.dto.response.StudentCouncilLoginResponse;
+import com.campus.campus.domain.council.application.exception.InvalidCouncilScopeException;
+import com.campus.campus.domain.council.application.exception.LoginIdAlreadyExistsException;
+import com.campus.campus.domain.council.application.exception.PasswordNotCollectException;
+import com.campus.campus.domain.council.application.exception.StudentCouncilNotFoundException;
+import com.campus.campus.domain.council.application.mapper.StudentCouncilLoginMapper;
+import com.campus.campus.domain.council.domain.entity.StudentCouncil;
+import com.campus.campus.domain.council.domain.repository.StudentCouncilRepository;
+import com.campus.campus.domain.school.application.exception.CollegeNotFoundException;
+import com.campus.campus.domain.school.application.exception.MajorNotFoundException;
+import com.campus.campus.domain.school.application.exception.SchoolCollegeNotSameException;
+import com.campus.campus.domain.school.application.exception.SchoolNotFoundException;
+import com.campus.campus.domain.school.domain.entity.College;
+import com.campus.campus.domain.school.domain.entity.Major;
+import com.campus.campus.domain.school.domain.entity.School;
+import com.campus.campus.domain.school.domain.repository.CollegeRepository;
+import com.campus.campus.domain.school.domain.repository.MajorRepository;
+import com.campus.campus.domain.school.domain.repository.SchoolRepository;
+import com.campus.campus.global.util.jwt.JwtProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CouncilLoginService {
+	private final StudentCouncilRepository studentCouncilRepository;
+	private final SchoolRepository schoolRepository;
+	private final CollegeRepository collegeRepository;
+	private final MajorRepository majorRepository;
+	private final StudentCouncilLoginMapper studentCouncilLoginMapper;
+	private final JwtProvider jwtProvider;
+	private final PasswordEncoder passwordEncoder;
+
+	@Transactional
+	public StudentCouncilLoginResponse signUp(StudentCouncilSignUpRequest studentCouncilSignUpRequest) {
+		if (studentCouncilRepository.existsByLoginId(studentCouncilSignUpRequest.loginId())) {
+			throw new LoginIdAlreadyExistsException();
+		}
+
+		School school = schoolRepository.findById(studentCouncilSignUpRequest.schoolId())
+			.orElseThrow(SchoolNotFoundException::new);
+
+		CouncilScope scope = validateCouncilScope(studentCouncilSignUpRequest, school);
+
+		StudentCouncil studentCouncil = studentCouncilLoginMapper.createStudentCouncil(
+			studentCouncilSignUpRequest, school, scope.college, scope.major);
+
+		studentCouncilRepository.save(studentCouncil);
+
+		String accessToken = jwtProvider.createCouncilAccessToken(studentCouncil.getId());
+		String refreshToken = jwtProvider.createCouncilRefreshToken(studentCouncil.getId());
+
+		return studentCouncilLoginMapper.toStudentCouncilLoginResponse(studentCouncil, accessToken, refreshToken);
+	}
+
+	public StudentCouncilLoginResponse login(StudentCouncilLoginRequest studentCouncilLoginRequest) {
+		StudentCouncil studentCouncil = studentCouncilRepository.findByLoginId(studentCouncilLoginRequest.loginId())
+			.orElseThrow(StudentCouncilNotFoundException::new);
+
+		if (!passwordEncoder.matches(studentCouncilLoginRequest.password(), studentCouncil.getPassword())) {
+			throw new PasswordNotCollectException();
+		}
+
+		String accessToken = jwtProvider.createCouncilAccessToken(studentCouncil.getId());
+		String refreshToken = jwtProvider.createCouncilRefreshToken(studentCouncil.getId());
+
+		return studentCouncilLoginMapper.toStudentCouncilLoginResponse(studentCouncil, accessToken, refreshToken);
+	}
+
+	private record CouncilScope(
+		College college,
+		Major major
+	) {
+
+	}
+
+	private CouncilScope validateCouncilScope(
+		StudentCouncilSignUpRequest studentCouncilSignUpRequest,
+		School school
+	) {
+		return switch (studentCouncilSignUpRequest.councilType()) {
+			case SCHOOL_COUNCIL -> {
+				if (studentCouncilSignUpRequest.collegeId() != null || studentCouncilSignUpRequest.majorId() != null) {
+					throw new InvalidCouncilScopeException();
+				}
+
+				yield new CouncilScope(null, null);
+			}
+
+			case COLLEGE_COUNCIL -> {
+				if (studentCouncilSignUpRequest.collegeId() == null || studentCouncilSignUpRequest.majorId() != null) {
+					throw new InvalidCouncilScopeException();
+				}
+
+				College college = collegeRepository.findById(studentCouncilSignUpRequest.collegeId())
+					.orElseThrow(CollegeNotFoundException::new);
+
+				if (!college.getSchool().getSchoolId().equals(school.getSchoolId())) {
+					throw new SchoolCollegeNotSameException();
+				}
+
+				yield new CouncilScope(college, null);
+			}
+
+			case MAJOR_COUNCIL -> {
+				if (studentCouncilSignUpRequest.majorId() == null) {
+					throw new InvalidCouncilScopeException();
+				}
+
+				College college = collegeRepository.findById(studentCouncilSignUpRequest.collegeId())
+					.orElseThrow(CollegeNotFoundException::new);
+
+				Major major = majorRepository.findById(studentCouncilSignUpRequest.majorId())
+					.orElseThrow(MajorNotFoundException::new);
+
+				if (!major.getSchool().getSchoolId().equals(school.getSchoolId())) {
+					throw new SchoolCollegeNotSameException();
+				}
+
+				yield new CouncilScope(college, major);
+			}
+		};
+	}
+}

--- a/src/main/java/com/campus/campus/domain/council/application/service/CouncilLoginService.java
+++ b/src/main/java/com/campus/campus/domain/council/application/service/CouncilLoginService.java
@@ -14,6 +14,8 @@ import com.campus.campus.domain.council.application.exception.StudentCouncilNotF
 import com.campus.campus.domain.council.application.mapper.StudentCouncilLoginMapper;
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.council.domain.repository.StudentCouncilRepository;
+import com.campus.campus.domain.mail.application.exception.EmailNotVerifiedException;
+import com.campus.campus.domain.mail.domain.repository.EmailVerificationRepository;
 import com.campus.campus.domain.school.application.exception.CollegeNotFoundException;
 import com.campus.campus.domain.school.application.exception.MajorNotFoundException;
 import com.campus.campus.domain.school.application.exception.SchoolCollegeNotSameException;
@@ -37,11 +39,14 @@ public class CouncilLoginService {
 	private final CollegeRepository collegeRepository;
 	private final MajorRepository majorRepository;
 	private final StudentCouncilLoginMapper studentCouncilLoginMapper;
+	private final EmailVerificationRepository emailVerificationRepository;
 	private final JwtProvider jwtProvider;
 	private final PasswordEncoder passwordEncoder;
 
 	@Transactional
 	public StudentCouncilLoginResponse signUp(StudentCouncilSignUpRequest studentCouncilSignUpRequest) {
+		checkVerifiedEmail(studentCouncilSignUpRequest.email());
+
 		if (studentCouncilRepository.existsByLoginId(studentCouncilSignUpRequest.loginId())) {
 			throw new LoginIdAlreadyExistsException();
 		}
@@ -129,5 +134,14 @@ public class CouncilLoginService {
 				yield new CouncilScope(college, major);
 			}
 		};
+	}
+
+	private void checkVerifiedEmail(String email) {
+		boolean exists = emailVerificationRepository
+			.existsByEmailAndVerifiedIsTrue(email);
+
+		if (!exists) {
+			throw new EmailNotVerifiedException();
+		}
 	}
 }

--- a/src/main/java/com/campus/campus/domain/council/application/service/CouncilLoginService.java
+++ b/src/main/java/com/campus/campus/domain/council/application/service/CouncilLoginService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilLoginRequest;
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilSignUpRequest;
 import com.campus.campus.domain.council.application.dto.response.StudentCouncilLoginResponse;
+import com.campus.campus.domain.council.application.exception.EmailAlreadyExistsException;
 import com.campus.campus.domain.council.application.exception.InvalidCouncilScopeException;
 import com.campus.campus.domain.council.application.exception.LoginIdAlreadyExistsException;
 import com.campus.campus.domain.council.application.exception.PasswordNotCollectException;
@@ -45,6 +46,9 @@ public class CouncilLoginService {
 
 	@Transactional
 	public StudentCouncilLoginResponse signUp(StudentCouncilSignUpRequest studentCouncilSignUpRequest) {
+		if (studentCouncilRepository.existsByEmail(studentCouncilSignUpRequest.email())) {
+			throw new EmailAlreadyExistsException();
+		}
 		checkVerifiedEmail(studentCouncilSignUpRequest.email());
 
 		if (studentCouncilRepository.existsByLoginId(studentCouncilSignUpRequest.loginId())) {

--- a/src/main/java/com/campus/campus/domain/council/domain/entity/CouncilType.java
+++ b/src/main/java/com/campus/campus/domain/council/domain/entity/CouncilType.java
@@ -1,0 +1,7 @@
+package com.campus.campus.domain.council.domain.entity;
+
+public enum CouncilType {
+	SCHOOL_COUNCIL, // 총학생회
+	COLLEGE_COUNCIL, // 단과대 학생회
+	MAJOR_COUNCIL // 학과 학생회
+}

--- a/src/main/java/com/campus/campus/domain/council/domain/entity/StudentCouncil.java
+++ b/src/main/java/com/campus/campus/domain/council/domain/entity/StudentCouncil.java
@@ -19,14 +19,14 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "student_councils")
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class StudentCouncil extends BaseEntity {

--- a/src/main/java/com/campus/campus/domain/council/domain/entity/StudentCouncil.java
+++ b/src/main/java/com/campus/campus/domain/council/domain/entity/StudentCouncil.java
@@ -3,6 +3,7 @@ package com.campus.campus.domain.council.domain.entity;
 import com.campus.campus.domain.school.domain.entity.College;
 import com.campus.campus.domain.school.domain.entity.Major;
 import com.campus.campus.domain.school.domain.entity.School;
+import com.campus.campus.global.entity.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -28,7 +29,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class StudentCouncil {
+public class StudentCouncil extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "student_council_id")

--- a/src/main/java/com/campus/campus/domain/council/domain/entity/StudentCouncil.java
+++ b/src/main/java/com/campus/campus/domain/council/domain/entity/StudentCouncil.java
@@ -40,6 +40,9 @@ public class StudentCouncil {
 	@Column(name = "password")
 	private String password;
 
+	@Column(name = "email")
+	private String email;
+
 	@Enumerated(EnumType.STRING)
 	@Column(name = "council_type", nullable = false)
 	private CouncilType councilType;

--- a/src/main/java/com/campus/campus/domain/council/domain/entity/StudentCouncil.java
+++ b/src/main/java/com/campus/campus/domain/council/domain/entity/StudentCouncil.java
@@ -1,0 +1,58 @@
+package com.campus.campus.domain.council.domain.entity;
+
+import com.campus.campus.domain.school.domain.entity.College;
+import com.campus.campus.domain.school.domain.entity.Major;
+import com.campus.campus.domain.school.domain.entity.School;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "student_councils")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class StudentCouncil {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "student_council_id")
+	private Long id;
+
+	@Column(name = "login_id")
+	private String loginId;
+
+	@Column(name = "password")
+	private String password;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "council_type", nullable = false)
+	private CouncilType councilType;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "school_id", nullable = false)
+	private School school;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "college_id")
+	private College college;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "major_id")
+	private Major major;
+}

--- a/src/main/java/com/campus/campus/domain/council/domain/repository/StudentCouncilRepository.java
+++ b/src/main/java/com/campus/campus/domain/council/domain/repository/StudentCouncilRepository.java
@@ -10,4 +10,6 @@ public interface StudentCouncilRepository extends JpaRepository<StudentCouncil, 
 	Optional<StudentCouncil> findByLoginId(String loginId);
 
 	boolean existsByLoginId(String loginId);
+
+	boolean existsByEmail(String email);
 }

--- a/src/main/java/com/campus/campus/domain/council/domain/repository/StudentCouncilRepository.java
+++ b/src/main/java/com/campus/campus/domain/council/domain/repository/StudentCouncilRepository.java
@@ -1,0 +1,13 @@
+package com.campus.campus.domain.council.domain.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.campus.campus.domain.council.domain.entity.StudentCouncil;
+
+public interface StudentCouncilRepository extends JpaRepository<StudentCouncil, Long> {
+	Optional<StudentCouncil> findByLoginId(String loginId);
+
+	boolean existsByLoginId(String loginId);
+}

--- a/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilLoginController.java
+++ b/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilLoginController.java
@@ -23,7 +23,7 @@ public class StudentCouncilLoginController {
 
 	@PostMapping("/signup")
 	@Operation(summary = "학생회 회원가입")
-	CommonResponse<StudentCouncilLoginResponse> Signup(
+	public CommonResponse<StudentCouncilLoginResponse> Signup(
 		@Valid @RequestBody StudentCouncilSignUpRequest studentCouncilSignUpRequest) {
 		StudentCouncilLoginResponse response = councilLoginService.signUp(studentCouncilSignUpRequest);
 
@@ -32,7 +32,7 @@ public class StudentCouncilLoginController {
 
 	@PostMapping("/login")
 	@Operation(summary = "학생회 로그인")
-	CommonResponse<StudentCouncilLoginResponse> Login(
+	public CommonResponse<StudentCouncilLoginResponse> Login(
 		@Valid @RequestBody StudentCouncilLoginRequest studentCouncilLoginRequest) {
 		StudentCouncilLoginResponse response = councilLoginService.login(studentCouncilLoginRequest);
 

--- a/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilLoginController.java
+++ b/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilLoginController.java
@@ -11,6 +11,7 @@ import com.campus.campus.domain.council.application.dto.response.StudentCouncilL
 import com.campus.campus.domain.council.application.service.CouncilLoginService;
 import com.campus.campus.global.common.response.CommonResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -21,6 +22,7 @@ public class StudentCouncilLoginController {
 	private final CouncilLoginService councilLoginService;
 
 	@PostMapping("/signup")
+	@Operation(summary = "학생회 회원가입")
 	CommonResponse<StudentCouncilLoginResponse> Signup(
 		@Valid @RequestBody StudentCouncilSignUpRequest studentCouncilSignUpRequest) {
 		StudentCouncilLoginResponse response = councilLoginService.signUp(studentCouncilSignUpRequest);
@@ -29,6 +31,7 @@ public class StudentCouncilLoginController {
 	}
 
 	@PostMapping("/login")
+	@Operation(summary = "학생회 로그인")
 	CommonResponse<StudentCouncilLoginResponse> Login(
 		@Valid @RequestBody StudentCouncilLoginRequest studentCouncilLoginRequest) {
 		StudentCouncilLoginResponse response = councilLoginService.login(studentCouncilLoginRequest);

--- a/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilLoginController.java
+++ b/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilLoginController.java
@@ -1,0 +1,38 @@
+package com.campus.campus.domain.council.presentation;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.campus.campus.domain.council.application.dto.request.StudentCouncilLoginRequest;
+import com.campus.campus.domain.council.application.dto.request.StudentCouncilSignUpRequest;
+import com.campus.campus.domain.council.application.dto.response.StudentCouncilLoginResponse;
+import com.campus.campus.domain.council.application.service.CouncilLoginService;
+import com.campus.campus.global.common.response.CommonResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth/council")
+public class StudentCouncilLoginController {
+	private final CouncilLoginService councilLoginService;
+
+	@PostMapping("/signup")
+	CommonResponse<StudentCouncilLoginResponse> Signup(
+		@Valid @RequestBody StudentCouncilSignUpRequest studentCouncilSignUpRequest) {
+		StudentCouncilLoginResponse response = councilLoginService.signUp(studentCouncilSignUpRequest);
+
+		return CommonResponse.success(StudentCouncilResponseCode.SIGNUP_SUCCESS, response);
+	}
+
+	@PostMapping("/login")
+	CommonResponse<StudentCouncilLoginResponse> Login(
+		@Valid @RequestBody StudentCouncilLoginRequest studentCouncilLoginRequest) {
+		StudentCouncilLoginResponse response = councilLoginService.login(studentCouncilLoginRequest);
+
+		return CommonResponse.success(StudentCouncilResponseCode.LOGIN_SUCCESS, response);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilResponseCode.java
@@ -1,0 +1,19 @@
+package com.campus.campus.domain.council.presentation;
+
+import org.springframework.http.HttpStatus;
+
+import com.campus.campus.global.common.response.ResponseCodeInterface;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum StudentCouncilResponseCode implements ResponseCodeInterface {
+	SIGNUP_SUCCESS(200, HttpStatus.OK, "학생회 회원가입에 성공했습니다."),
+	LOGIN_SUCCESS(200, HttpStatus.OK, "학생회 로그인에 성공했습니다.");
+
+	private final int code;
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/com/campus/campus/domain/mail/application/dto/request/EmailVerificationConfirmRequest.java
+++ b/src/main/java/com/campus/campus/domain/mail/application/dto/request/EmailVerificationConfirmRequest.java
@@ -1,0 +1,15 @@
+package com.campus.campus.domain.mail.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailVerificationConfirmRequest(
+	@Schema(description = "인증할 이메일", example = "campus@campus.com")
+	@NotBlank
+	String email,
+
+	@Schema(description = "인증 코드", example = "123456")
+	@NotBlank
+	String code
+) {
+}

--- a/src/main/java/com/campus/campus/domain/mail/application/dto/request/EmailVerificationRequest.java
+++ b/src/main/java/com/campus/campus/domain/mail/application/dto/request/EmailVerificationRequest.java
@@ -1,0 +1,11 @@
+package com.campus.campus.domain.mail.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailVerificationRequest(
+	@Schema(description = "인증할 이메일", example = "campus@campus.com")
+	@NotBlank
+	String email
+) {
+}

--- a/src/main/java/com/campus/campus/domain/mail/application/exception/EmailNotVerifiedException.java
+++ b/src/main/java/com/campus/campus/domain/mail/application/exception/EmailNotVerifiedException.java
@@ -1,0 +1,9 @@
+package com.campus.campus.domain.mail.application.exception;
+
+import com.campus.campus.global.common.exception.ApplicationException;
+
+public class EmailNotVerifiedException extends ApplicationException {
+	public EmailNotVerifiedException() {
+		super(ErrorCode.EMAIL_NOT_VERIFIED);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/mail/application/exception/EmailVerificationNotFoundException.java
+++ b/src/main/java/com/campus/campus/domain/mail/application/exception/EmailVerificationNotFoundException.java
@@ -1,0 +1,9 @@
+package com.campus.campus.domain.mail.application.exception;
+
+import com.campus.campus.global.common.exception.ApplicationException;
+
+public class EmailVerificationNotFoundException extends ApplicationException {
+	public EmailVerificationNotFoundException() {
+		super(ErrorCode.EMAIL_VERIFICATION_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/mail/application/exception/ErrorCode.java
+++ b/src/main/java/com/campus/campus/domain/mail/application/exception/ErrorCode.java
@@ -12,7 +12,8 @@ import lombok.Getter;
 public enum ErrorCode implements ErrorCodeInterface {
 	EMAIL_VERIFICATION_NOT_FOUND(2400, HttpStatus.NOT_FOUND, "해당 이메일 인증 정보가 존재하지 않습니다."),
 	VERIFICATION_CODE_EXPIRED(2401, HttpStatus.REQUEST_TIMEOUT, "인증 코드가 만료되었습니다."),
-	VERIFICATION_CODE_NOT_MATCH(2402, HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다.");
+	VERIFICATION_CODE_NOT_MATCH(2402, HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
+	EMAIL_NOT_VERIFIED(2403, HttpStatus.UNAUTHORIZED, "이메일 인증이 되지 않았습니다.");
 
 	private final int code;
 	private final HttpStatus status;

--- a/src/main/java/com/campus/campus/domain/mail/application/exception/ErrorCode.java
+++ b/src/main/java/com/campus/campus/domain/mail/application/exception/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.campus.campus.domain.mail.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.campus.campus.global.common.exception.ErrorCodeInterface;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode implements ErrorCodeInterface {
+	EMAIL_VERIFICATION_NOT_FOUND(2400, HttpStatus.NOT_FOUND, "해당 이메일 인증 정보가 존재하지 않습니다."),
+	VERIFICATION_CODE_EXPIRED(2401, HttpStatus.REQUEST_TIMEOUT, "인증 코드가 만료되었습니다."),
+	VERIFICATION_CODE_NOT_MATCH(2402, HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다.");
+
+	private final int code;
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/com/campus/campus/domain/mail/application/exception/VerificationCodeExpiredException.java
+++ b/src/main/java/com/campus/campus/domain/mail/application/exception/VerificationCodeExpiredException.java
@@ -1,0 +1,9 @@
+package com.campus.campus.domain.mail.application.exception;
+
+import com.campus.campus.global.common.exception.ApplicationException;
+
+public class VerificationCodeExpiredException extends ApplicationException {
+	public VerificationCodeExpiredException() {
+		super(ErrorCode.VERIFICATION_CODE_NOT_MATCH);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/mail/application/exception/VerificationCodeExpiredException.java
+++ b/src/main/java/com/campus/campus/domain/mail/application/exception/VerificationCodeExpiredException.java
@@ -4,6 +4,6 @@ import com.campus.campus.global.common.exception.ApplicationException;
 
 public class VerificationCodeExpiredException extends ApplicationException {
 	public VerificationCodeExpiredException() {
-		super(ErrorCode.VERIFICATION_CODE_NOT_MATCH);
+		super(ErrorCode.VERIFICATION_CODE_EXPIRED);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/mail/application/exception/VerificationCodeNotMatchException.java
+++ b/src/main/java/com/campus/campus/domain/mail/application/exception/VerificationCodeNotMatchException.java
@@ -4,6 +4,6 @@ import com.campus.campus.global.common.exception.ApplicationException;
 
 public class VerificationCodeNotMatchException extends ApplicationException {
 	public VerificationCodeNotMatchException() {
-		super(ErrorCode.EMAIL_VERIFICATION_NOT_FOUND);
+		super(ErrorCode.VERIFICATION_CODE_NOT_MATCH);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/mail/application/exception/VerificationCodeNotMatchException.java
+++ b/src/main/java/com/campus/campus/domain/mail/application/exception/VerificationCodeNotMatchException.java
@@ -1,0 +1,9 @@
+package com.campus.campus.domain.mail.application.exception;
+
+import com.campus.campus.global.common.exception.ApplicationException;
+
+public class VerificationCodeNotMatchException extends ApplicationException {
+	public VerificationCodeNotMatchException() {
+		super(ErrorCode.EMAIL_VERIFICATION_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/mail/application/mapper/EmailVerificationMapper.java
+++ b/src/main/java/com/campus/campus/domain/mail/application/mapper/EmailVerificationMapper.java
@@ -1,0 +1,21 @@
+package com.campus.campus.domain.mail.application.mapper;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Component;
+
+import com.campus.campus.domain.mail.application.dto.request.EmailVerificationRequest;
+import com.campus.campus.domain.mail.domain.entity.EmailVerification;
+
+@Component
+public class EmailVerificationMapper {
+	public EmailVerification createEmailVerification(String email, String code,
+		LocalDateTime expireTime) {
+		return EmailVerification.builder()
+			.email(email)
+			.code(code)
+			.expiresAt(expireTime)
+			.verified(false)
+			.build();
+	}
+}

--- a/src/main/java/com/campus/campus/domain/mail/application/service/EmailVerificationService.java
+++ b/src/main/java/com/campus/campus/domain/mail/application/service/EmailVerificationService.java
@@ -49,7 +49,7 @@ public class EmailVerificationService {
 				
 				인증 코드 : %s
 				
-				10분 이내에 입력해주세요.
+				5분 이내에 입력해주세요.
 				""".formatted(code)
 		);
 

--- a/src/main/java/com/campus/campus/domain/mail/application/service/EmailVerificationService.java
+++ b/src/main/java/com/campus/campus/domain/mail/application/service/EmailVerificationService.java
@@ -1,0 +1,81 @@
+package com.campus.campus.domain.mail.application.service;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.campus.campus.domain.mail.application.dto.request.EmailVerificationConfirmRequest;
+import com.campus.campus.domain.mail.application.exception.EmailVerificationNotFoundException;
+import com.campus.campus.domain.mail.application.exception.VerificationCodeExpiredException;
+import com.campus.campus.domain.mail.application.exception.VerificationCodeNotMatchException;
+import com.campus.campus.domain.mail.application.mapper.EmailVerificationMapper;
+import com.campus.campus.domain.mail.domain.entity.EmailVerification;
+import com.campus.campus.domain.mail.domain.repository.EmailVerificationRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EmailVerificationService {
+	private static final long EXPIRE_TIME = 5L;
+
+	private final JavaMailSender javaMailSender;
+	private final EmailVerificationMapper emailVerificationMapper;
+	private final EmailVerificationRepository emailVerificationRepository;
+
+	@Transactional
+	public void sendVerificationCode(String email) {
+		String code = createCode();
+		LocalDateTime expireTime = LocalDateTime.now().plusMinutes(EXPIRE_TIME);
+
+		EmailVerification emailVerification = emailVerificationMapper.createEmailVerification(email, code, expireTime);
+		emailVerificationRepository.save(emailVerification);
+
+		sendMail(email, code);
+	}
+
+	public void sendMail(String to, String code) {
+		SimpleMailMessage message = new SimpleMailMessage();
+		message.setTo(to);
+		message.setSubject("[Campus] 학생회 회원가입 이메일 인증 코드");
+		message.setText(
+			"""
+				Campus 학생회 회원가입을 위한 이메일 인증 코드입니다.
+				
+				인증 코드 : %s
+				
+				10분 이내에 입력해주세요.
+				""".formatted(code)
+		);
+
+		javaMailSender.send(message);
+	}
+
+	@Transactional
+	public void verifyCode(EmailVerificationConfirmRequest emailVerificationConfirmRequest) {
+		EmailVerification emailVerification = emailVerificationRepository.
+			findTopByEmailOrderByEmailVerificationIdDesc(emailVerificationConfirmRequest.email())
+			.orElseThrow(EmailVerificationNotFoundException::new);
+
+		if (emailVerification.isExpired()) {
+			emailVerificationRepository.delete(emailVerification);
+			throw new VerificationCodeExpiredException();
+		}
+
+		if (!emailVerification.getCode().equals(emailVerificationConfirmRequest.code())) {
+			throw new VerificationCodeNotMatchException();
+		}
+
+		emailVerification.verify();
+	}
+
+	private String createCode() {
+		int code = ThreadLocalRandom.current().nextInt(100000, 1000000);
+		return String.valueOf(code);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/mail/domain/entity/EmailVerification.java
+++ b/src/main/java/com/campus/campus/domain/mail/domain/entity/EmailVerification.java
@@ -12,14 +12,14 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "email_verifications")
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class EmailVerification extends BaseEntity {

--- a/src/main/java/com/campus/campus/domain/mail/domain/entity/EmailVerification.java
+++ b/src/main/java/com/campus/campus/domain/mail/domain/entity/EmailVerification.java
@@ -1,0 +1,48 @@
+package com.campus.campus.domain.mail.domain.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "email_verifications")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class EmailVerification {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "email_verification_id")
+	private Long emailVerificationId;
+
+	@Column(name = "email", nullable = false)
+	private String email;
+
+	@Column(name = "code", nullable = false, length = 6)
+	private String code;
+
+	@Column(name = "expires_at", nullable = false)
+	private LocalDateTime expiresAt;
+
+	@Column(name = "verified", nullable = false)
+	private boolean verified;
+
+	public boolean isExpired() {
+		return expiresAt.isBefore(LocalDateTime.now());
+	}
+
+	public void verify() {
+		this.verified = true;
+	}
+}

--- a/src/main/java/com/campus/campus/domain/mail/domain/entity/EmailVerification.java
+++ b/src/main/java/com/campus/campus/domain/mail/domain/entity/EmailVerification.java
@@ -2,6 +2,8 @@ package com.campus.campus.domain.mail.domain.entity;
 
 import java.time.LocalDateTime;
 
+import com.campus.campus.global.entity.BaseEntity;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -20,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class EmailVerification {
+public class EmailVerification extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "email_verification_id")

--- a/src/main/java/com/campus/campus/domain/mail/domain/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/campus/campus/domain/mail/domain/repository/EmailVerificationRepository.java
@@ -8,4 +8,7 @@ import com.campus.campus.domain.mail.domain.entity.EmailVerification;
 
 public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
 	Optional<EmailVerification> findTopByEmailOrderByEmailVerificationIdDesc(String email);
+
+	boolean existsByEmailAndVerifiedIsTrue(String email);
+
 }

--- a/src/main/java/com/campus/campus/domain/mail/domain/repository/EmailVerificationRepository.java
+++ b/src/main/java/com/campus/campus/domain/mail/domain/repository/EmailVerificationRepository.java
@@ -1,0 +1,11 @@
+package com.campus.campus.domain.mail.domain.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.campus.campus.domain.mail.domain.entity.EmailVerification;
+
+public interface EmailVerificationRepository extends JpaRepository<EmailVerification, Long> {
+	Optional<EmailVerification> findTopByEmailOrderByEmailVerificationIdDesc(String email);
+}

--- a/src/main/java/com/campus/campus/domain/mail/presentation/EmailVerificationController.java
+++ b/src/main/java/com/campus/campus/domain/mail/presentation/EmailVerificationController.java
@@ -1,0 +1,39 @@
+package com.campus.campus.domain.mail.presentation;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.campus.campus.domain.mail.application.dto.request.EmailVerificationConfirmRequest;
+import com.campus.campus.domain.mail.application.dto.request.EmailVerificationRequest;
+import com.campus.campus.domain.mail.application.service.EmailVerificationService;
+import com.campus.campus.global.common.response.CommonResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth/council/signup/email")
+public class EmailVerificationController {
+	private final EmailVerificationService emailVerificationService;
+
+	@PostMapping("/code")
+	CommonResponse<Void> sendSignupVerificationCodeEmail(
+		@Valid @RequestBody EmailVerificationRequest emailVerificationRequest
+	) {
+		emailVerificationService.sendVerificationCode(emailVerificationRequest.email());
+
+		return CommonResponse.success(EmailVerificationResponseCode.EMAIL_SEND_SUCCESS);
+	}
+
+	@PostMapping("/code/verify")
+	CommonResponse<Void> verifyVerificationCode(
+		@Valid @RequestBody EmailVerificationConfirmRequest emailVerificationConfirmRequest
+	) {
+		emailVerificationService.verifyCode(emailVerificationConfirmRequest);
+
+		return CommonResponse.success(EmailVerificationResponseCode.VERIFY_SUCCESS);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/mail/presentation/EmailVerificationController.java
+++ b/src/main/java/com/campus/campus/domain/mail/presentation/EmailVerificationController.java
@@ -22,7 +22,7 @@ public class EmailVerificationController {
 
 	@PostMapping("/code")
 	@Operation(summary = "이메일 인증 코드 전송")
-	CommonResponse<Void> sendSignupVerificationCodeEmail(
+	public CommonResponse<Void> sendSignupVerificationCodeEmail(
 		@Valid @RequestBody EmailVerificationRequest emailVerificationRequest
 	) {
 		emailVerificationService.sendVerificationCode(emailVerificationRequest.email());
@@ -32,7 +32,7 @@ public class EmailVerificationController {
 
 	@PostMapping("/code/verify")
 	@Operation(summary = "인증 코드 검증")
-	CommonResponse<Void> verifyVerificationCode(
+	public CommonResponse<Void> verifyVerificationCode(
 		@Valid @RequestBody EmailVerificationConfirmRequest emailVerificationConfirmRequest
 	) {
 		emailVerificationService.verifyCode(emailVerificationConfirmRequest);

--- a/src/main/java/com/campus/campus/domain/mail/presentation/EmailVerificationController.java
+++ b/src/main/java/com/campus/campus/domain/mail/presentation/EmailVerificationController.java
@@ -10,6 +10,7 @@ import com.campus.campus.domain.mail.application.dto.request.EmailVerificationRe
 import com.campus.campus.domain.mail.application.service.EmailVerificationService;
 import com.campus.campus.global.common.response.CommonResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -20,6 +21,7 @@ public class EmailVerificationController {
 	private final EmailVerificationService emailVerificationService;
 
 	@PostMapping("/code")
+	@Operation(summary = "이메일 인증 코드 전송")
 	CommonResponse<Void> sendSignupVerificationCodeEmail(
 		@Valid @RequestBody EmailVerificationRequest emailVerificationRequest
 	) {
@@ -29,6 +31,7 @@ public class EmailVerificationController {
 	}
 
 	@PostMapping("/code/verify")
+	@Operation(summary = "인증 코드 검증")
 	CommonResponse<Void> verifyVerificationCode(
 		@Valid @RequestBody EmailVerificationConfirmRequest emailVerificationConfirmRequest
 	) {

--- a/src/main/java/com/campus/campus/domain/mail/presentation/EmailVerificationResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/mail/presentation/EmailVerificationResponseCode.java
@@ -1,0 +1,19 @@
+package com.campus.campus.domain.mail.presentation;
+
+import org.springframework.http.HttpStatus;
+
+import com.campus.campus.global.common.response.ResponseCodeInterface;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum EmailVerificationResponseCode implements ResponseCodeInterface {
+	EMAIL_SEND_SUCCESS(200, HttpStatus.OK, "성공적으로 이메일이 전송되었습니다."),
+	VERIFY_SUCCESS(200, HttpStatus.OK, "인증에 성공하였습니다.");
+
+	private final int code;
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/com/campus/campus/domain/school/application/exception/CollegeNotFoundException.java
+++ b/src/main/java/com/campus/campus/domain/school/application/exception/CollegeNotFoundException.java
@@ -1,0 +1,9 @@
+package com.campus.campus.domain.school.application.exception;
+
+import com.campus.campus.global.common.exception.ApplicationException;
+
+public class CollegeNotFoundException extends ApplicationException {
+	public CollegeNotFoundException() {
+		super(ErrorCode.COLLEGE_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/school/application/exception/ErrorCode.java
+++ b/src/main/java/com/campus/campus/domain/school/application/exception/ErrorCode.java
@@ -10,9 +10,11 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode implements ErrorCodeInterface {
-	SCHOOL_NOT_FOUND_EXCEPTION(2200, HttpStatus.NOT_FOUND, "해당 학교는 존재하지 않습니다."),
-	MAJOR_NOT_FOUND_EXCEPTION(2201, HttpStatus.NOT_FOUND, "해당 학과는 존재하지 않습니다."),
-	SCHOOL_MAJOR_NOT_SAME(2202, HttpStatus.BAD_REQUEST, "선택한 학교와 전공이 일치하지 않습니다.");
+	SCHOOL_NOT_FOUND(2200, HttpStatus.NOT_FOUND, "해당 학교는 존재하지 않습니다."),
+	MAJOR_NOT_FOUND(2201, HttpStatus.NOT_FOUND, "해당 학과는 존재하지 않습니다."),
+	COLLEGE_NOT_FOUND(2202, HttpStatus.NOT_FOUND, "해당 단과대는 존재하지 않습니다."),
+	SCHOOL_COLLEGE_NOT_SAME(2203, HttpStatus.BAD_REQUEST, "선택한 학과와 단과대가 일치하지 않습니다."),
+	SCHOOL_MAJOR_NOT_SAME(2204, HttpStatus.BAD_REQUEST, "선택한 학교와 전공이 일치하지 않습니다.");
 
 	private final int code;
 	private final HttpStatus status;

--- a/src/main/java/com/campus/campus/domain/school/application/exception/ErrorCode.java
+++ b/src/main/java/com/campus/campus/domain/school/application/exception/ErrorCode.java
@@ -13,7 +13,7 @@ public enum ErrorCode implements ErrorCodeInterface {
 	SCHOOL_NOT_FOUND(2200, HttpStatus.NOT_FOUND, "해당 학교는 존재하지 않습니다."),
 	MAJOR_NOT_FOUND(2201, HttpStatus.NOT_FOUND, "해당 학과는 존재하지 않습니다."),
 	COLLEGE_NOT_FOUND(2202, HttpStatus.NOT_FOUND, "해당 단과대는 존재하지 않습니다."),
-	SCHOOL_COLLEGE_NOT_SAME(2203, HttpStatus.BAD_REQUEST, "선택한 학과와 단과대가 일치하지 않습니다."),
+	SCHOOL_COLLEGE_NOT_SAME(2203, HttpStatus.BAD_REQUEST, "선택한 학교와 단과대가 일치하지 않습니다."),
 	SCHOOL_MAJOR_NOT_SAME(2204, HttpStatus.BAD_REQUEST, "선택한 학교와 전공이 일치하지 않습니다.");
 
 	private final int code;

--- a/src/main/java/com/campus/campus/domain/school/application/exception/MajorNotFoundException.java
+++ b/src/main/java/com/campus/campus/domain/school/application/exception/MajorNotFoundException.java
@@ -4,6 +4,6 @@ import com.campus.campus.global.common.exception.ApplicationException;
 
 public class MajorNotFoundException extends ApplicationException {
 	public MajorNotFoundException() {
-		super(ErrorCode.MAJOR_NOT_FOUND_EXCEPTION);
+		super(ErrorCode.MAJOR_NOT_FOUND);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/school/application/exception/SchoolCollegeNotSameException.java
+++ b/src/main/java/com/campus/campus/domain/school/application/exception/SchoolCollegeNotSameException.java
@@ -1,0 +1,9 @@
+package com.campus.campus.domain.school.application.exception;
+
+import com.campus.campus.global.common.exception.ApplicationException;
+
+public class SchoolCollegeNotSameException extends ApplicationException {
+	public SchoolCollegeNotSameException() {
+		super(ErrorCode.SCHOOL_COLLEGE_NOT_SAME);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/school/application/exception/SchoolNotFoundException.java
+++ b/src/main/java/com/campus/campus/domain/school/application/exception/SchoolNotFoundException.java
@@ -4,6 +4,6 @@ import com.campus.campus.global.common.exception.ApplicationException;
 
 public class SchoolNotFoundException extends ApplicationException {
 	public SchoolNotFoundException() {
-		super(ErrorCode.SCHOOL_NOT_FOUND_EXCEPTION);
+		super(ErrorCode.SCHOOL_NOT_FOUND);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/user/domain/entity/User.java
+++ b/src/main/java/com/campus/campus/domain/user/domain/entity/User.java
@@ -3,6 +3,7 @@ package com.campus.campus.domain.user.domain.entity;
 import com.campus.campus.domain.school.domain.entity.College;
 import com.campus.campus.domain.school.domain.entity.Major;
 import com.campus.campus.domain.school.domain.entity.School;
+import com.campus.campus.global.entity.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -25,7 +26,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class User {
+public class User extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "user_id")

--- a/src/main/java/com/campus/campus/domain/user/domain/entity/User.java
+++ b/src/main/java/com/campus/campus/domain/user/domain/entity/User.java
@@ -16,14 +16,14 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Table(name = "users")
 @Getter
-@Builder
+@SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class User extends BaseEntity {

--- a/src/main/java/com/campus/campus/domain/user/presentation/AuthController.java
+++ b/src/main/java/com/campus/campus/domain/user/presentation/AuthController.java
@@ -9,6 +9,7 @@ import com.campus.campus.global.auth.application.dto.OauthLoginResponse;
 import com.campus.campus.domain.user.application.service.KakaoOauthService;
 import com.campus.campus.global.common.response.CommonResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -18,6 +19,7 @@ public class AuthController {
 	private final KakaoOauthService kakaoOauthService;
 
 	@PostMapping("/kakao")
+	@Operation(summary = "카카오 로그인")
 	public CommonResponse<OauthLoginResponse> kakaoLogin(@RequestParam("code") String code) {
 		OauthLoginResponse response = kakaoOauthService.login(code);
 

--- a/src/main/java/com/campus/campus/domain/user/presentation/UserController.java
+++ b/src/main/java/com/campus/campus/domain/user/presentation/UserController.java
@@ -11,6 +11,7 @@ import com.campus.campus.domain.user.application.service.UserService;
 import com.campus.campus.global.auth.annotation.CurrentUserId;
 import com.campus.campus.global.common.response.CommonResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -21,6 +22,7 @@ public class UserController {
 	private final UserService userService;
 
 	@PatchMapping("/profile")
+	@Operation(summary = "최초 로그인 사용자 학적정보 입력")
 	public CommonResponse<UserFirstProfileResponse> createUserProfile(@CurrentUserId Long userId,
 		@RequestBody @Valid UserProfileRequest userProfileRequest) {
 		UserFirstProfileResponse userFirstProfileResponse = userService.writeUserProfile(userId, userProfileRequest);

--- a/src/main/java/com/campus/campus/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/campus/campus/global/config/PermitUrlConfig.java
@@ -12,7 +12,9 @@ public class PermitUrlConfig {
 			"/actuator/health",
 			"/auth/login/kakao",
 			"/auth/council/signup",
-			"/auth/council/login"
+			"/auth/council/login",
+			"/auth/council/signup/email/code",
+			"/auth/council/signup/email/code/verify"
 		};
 	}
 }

--- a/src/main/java/com/campus/campus/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/campus/campus/global/config/PermitUrlConfig.java
@@ -10,7 +10,9 @@ public class PermitUrlConfig {
 			"/swagger-ui/**",
 			"/health-check",
 			"/actuator/health",
-			"/auth/login/kakao"
+			"/auth/login/kakao",
+			"/auth/council/signup",
+			"/auth/council/login"
 		};
 	}
 }

--- a/src/main/java/com/campus/campus/global/config/SecurityConfig.java
+++ b/src/main/java/com/campus/campus/global/config/SecurityConfig.java
@@ -29,7 +29,8 @@ public class SecurityConfig {
 	private final PermitUrlConfig permitUrlConfig;
 
 	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+	public SecurityFilterChain securityFilterChain(HttpSecurity http,
+		JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
 		http
 			.cors(Customizer.withDefaults())
 			.csrf(AbstractHttpConfigurer::disable)
@@ -48,7 +49,8 @@ public class SecurityConfig {
 	public CorsConfigurationSource corsConfig() {
 		CorsConfiguration cfg = new CorsConfiguration();
 		cfg.setAllowedOrigins(
-			List.of("http://localhost:3000", "http://localhost:5173", "https://138.2.121.208.nip.io"));
+			List.of("http://localhost:3000", "http://localhost:5173", "https://138.2.121.208.nip.io",
+				"http://158.179.193.224:8080"));
 		cfg.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
 		cfg.setAllowedHeaders(List.of("Authorization", "Content-Type"));
 		cfg.setExposedHeaders(List.of("Authorization", "RefreshToken"));

--- a/src/main/java/com/campus/campus/global/config/SecurityConfig.java
+++ b/src/main/java/com/campus/campus/global/config/SecurityConfig.java
@@ -9,6 +9,8 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -55,5 +57,10 @@ public class SecurityConfig {
 		UrlBasedCorsConfigurationSource src = new UrlBasedCorsConfigurationSource();
 		src.registerCorsConfiguration("/**", cfg);
 		return src;
+	}
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
 	}
 }

--- a/src/main/java/com/campus/campus/global/entity/BaseEntity.java
+++ b/src/main/java/com/campus/campus/global/entity/BaseEntity.java
@@ -1,0 +1,29 @@
+package com.campus.campus.global.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@MappedSuperclass
+@SuperBuilder
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+	@CreatedDate
+	@Column(name = "created_at", nullable = false, updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/campus/campus/global/util/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/campus/campus/global/util/jwt/JwtAuthenticationFilter.java
@@ -5,16 +5,21 @@ import java.io.IOException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.campus.campus.domain.council.application.exception.StudentCouncilNotFoundException;
+import com.campus.campus.domain.council.domain.entity.StudentCouncil;
+import com.campus.campus.domain.council.domain.repository.StudentCouncilRepository;
 import com.campus.campus.domain.user.application.exception.UserNotFoundException;
 import com.campus.campus.domain.user.domain.entity.User;
 import com.campus.campus.domain.user.domain.repository.UserRepository;
 import com.campus.campus.global.util.jwt.exception.ExpireJwtException;
 import com.campus.campus.global.util.jwt.exception.InvalidJwtException;
 
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -28,6 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private final JwtAuthenticator jwtAuthenticator;
 	private final JwtProvider jwtProvider;
 	private final UserRepository userRepository;
+	private final StudentCouncilRepository studentCouncilRepository;
 
 	@Override
 	protected void doFilterInternal(
@@ -63,18 +69,30 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private Authentication createAuthentication(String token, HttpServletRequest request) {
 		jwtAuthenticator.verifyAccessToken(token);
 
-		Long userId = jwtProvider.getUserIdFromAccessToken(token);
+		Claims claims = jwtAuthenticator.parseAccessToken(token).getPayload();
+		String role = claims.get("role", String.class);
+		String subject = claims.getSubject();
 
-		User user = userRepository.findById(userId)
-			.orElseThrow(UserNotFoundException::new);
-
-		UserPrincipal userPrincipal = UserPrincipal.from(user);
+		UserDetails principal;
+		if ("USER".equals(role)) {
+			Long userId = Long.valueOf(subject);
+			User user = userRepository.findById(userId)
+				.orElseThrow(UserNotFoundException::new);
+			principal = UserPrincipal.from(user);
+		} else if ("COUNCIL".equals(role)) {
+			Long councilId = Long.valueOf(subject);
+			StudentCouncil council = studentCouncilRepository.findById(councilId)
+				.orElseThrow(StudentCouncilNotFoundException::new);
+			principal = StudentCouncilPrincipal.from(council);
+		} else {
+			throw new InvalidJwtException();
+		}
 
 		UsernamePasswordAuthenticationToken authentication =
 			new UsernamePasswordAuthenticationToken(
-				userPrincipal,
+				principal,
 				null,
-				userPrincipal.getAuthorities()
+				principal.getAuthorities()
 			);
 
 		authentication.setDetails(

--- a/src/main/java/com/campus/campus/global/util/jwt/JwtProvider.java
+++ b/src/main/java/com/campus/campus/global/util/jwt/JwtProvider.java
@@ -8,6 +8,8 @@ import javax.crypto.SecretKey;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.campus.campus.global.util.jwt.exception.InvalidJwtException;
+
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import jakarta.annotation.PostConstruct;
@@ -41,6 +43,7 @@ public class JwtProvider {
 			.subject(String.valueOf(userId))
 			.issuedAt(Date.from(now))
 			.expiration(Date.from(now.plusSeconds(accessTokenExpirationSeconds)))
+			.claim("role", "USER")
 			.signWith(accessKey)
 			.compact();
 	}
@@ -51,12 +54,49 @@ public class JwtProvider {
 			.subject(String.valueOf(userId))
 			.issuedAt(Date.from(now))
 			.expiration(Date.from(now.plusSeconds(refreshTokenExpirationSeconds)))
+			.claim("role", "USER")
 			.signWith(refreshKey)
 			.compact();
 	}
 
 	public Long getUserIdFromAccessToken(String token) {
 		Claims claims = jwtAuthenticator.parseAccessToken(token).getPayload();
+		String role = claims.get("role", String.class);
+		if (!"USER".equals(role)) {
+			throw new InvalidJwtException();
+		}
+
+		return Long.valueOf(claims.getSubject());
+	}
+
+	public String createCouncilAccessToken(Long councilId) {
+		Instant now = Instant.now();
+		return Jwts.builder()
+			.subject(String.valueOf(councilId))
+			.issuedAt(Date.from(now))
+			.expiration(Date.from(now.plusSeconds(accessTokenExpirationSeconds)))
+			.claim("role", "COUNCIL")
+			.signWith(accessKey)
+			.compact();
+	}
+
+	public String createCouncilRefreshToken(Long councilId) {
+		Instant now = Instant.now();
+		return Jwts.builder()
+			.subject(String.valueOf(councilId))
+			.issuedAt(Date.from(now))
+			.expiration(Date.from(now.plusSeconds(refreshTokenExpirationSeconds)))
+			.claim("role", "COUNCIL")
+			.signWith(refreshKey)
+			.compact();
+	}
+
+	public Long getCouncilIdFromAccessToken(String token) {
+		Claims claims = jwtAuthenticator.parseAccessToken(token).getPayload();
+		String role = claims.get("role", String.class);
+		if (!"COUNCIL".equals(role)) {
+			throw new InvalidJwtException();
+		}
 		return Long.valueOf(claims.getSubject());
 	}
 }

--- a/src/main/java/com/campus/campus/global/util/jwt/StudentCouncilPrincipal.java
+++ b/src/main/java/com/campus/campus/global/util/jwt/StudentCouncilPrincipal.java
@@ -1,0 +1,78 @@
+package com.campus.campus.global.util.jwt;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.campus.campus.domain.council.domain.entity.CouncilType;
+import com.campus.campus.domain.council.domain.entity.StudentCouncil;
+
+import lombok.Getter;
+
+@Getter
+public class StudentCouncilPrincipal implements UserDetails {
+	private final Long councilId;
+	private final String username; // 로그인 아이디 (이메일)
+	private final CouncilType councilType;
+	private final List<GrantedAuthority> authorities;
+
+	private StudentCouncilPrincipal(
+		Long councilId,
+		String username,
+		CouncilType councilType,
+		List<GrantedAuthority> authorities
+	) {
+		this.councilId = councilId;
+		this.username = username;
+		this.councilType = councilType;
+		this.authorities = authorities;
+	}
+
+	public static StudentCouncilPrincipal from(StudentCouncil studentCouncil) {
+		List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_COUNCIL"));
+		return new StudentCouncilPrincipal(
+			studentCouncil.getId(),
+			studentCouncil.getLoginId(),
+			studentCouncil.getCouncilType(),
+			authorities
+		);
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return authorities;
+	}
+
+	@Override
+	public String getPassword() {
+		return null; // 인증에서 비밀번호는 안 씀
+	}
+
+	@Override
+	public String getUsername() {
+		return username;
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,6 +14,18 @@ spring:
         default_batch_fetch_size: 100
     hibernate:
       ddl-auto: update
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: illta.campus
+    password: ENC(bpaxv19TGzpHFiIiKCYIvuITX5WPYgjfmryQ0riUFvg=)
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 oauth:
   kakao:
     client-id: ENC(G6gZHtP5QYz7+G6herJ1QCSbdVYgjtGnx8MhBSxLDFx26Yh0YQQ+uZ6RQ7wbvS17)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -30,7 +30,7 @@ oauth:
   kakao:
     client-id: ENC(G6gZHtP5QYz7+G6herJ1QCSbdVYgjtGnx8MhBSxLDFx26Yh0YQQ+uZ6RQ7wbvS17)
     client-secret: ENC(CG823WHRi6g4ybTc/VEOfd43c/RxVnIAE+AVpYWqrE/2xnGkvtjKkVSVVOXkXBXo)
-    redirect-uri: "http://localhost:3000/auth/login/kakao"
+    redirect-uri: "http://158.179.193.224:8080/auth/login/kakao"
 
 jwt:
   access:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -14,6 +14,18 @@ spring:
         default_batch_fetch_size: 100
     hibernate:
       ddl-auto: update
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: illta.campus
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 oauth:
   kakao:
     client-id: ${REST_API_KEY}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -14,6 +14,18 @@ spring:
         default_batch_fetch_size: 100
     hibernate:
       ddl-auto: update
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: illta.campus
+    password: ENC(bpaxv19TGzpHFiIiKCYIvuITX5WPYgjfmryQ0riUFvg=)
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 oauth:
   kakao:
     client-id: ENC(G6gZHtP5QYz7+G6herJ1QCSbdVYgjtGnx8MhBSxLDFx26Yh0YQQ+uZ6RQ7wbvS17)

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -10,6 +10,18 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: illta.campus
+    password: abcd efgh ijkl mnop
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 oauth:
   kakao:
     client-id: 2fb31q4aeb2877d3408aac80b3ddb2c5
@@ -25,3 +37,8 @@ jwt:
     expiration-seconds: 1209600
 
 server-uri: http://localhost
+
+management:
+  health:
+    mail:
+      enabled: false


### PR DESCRIPTION
## 🔀 변경 내용
- 학생회 회원가입 기능을 구현했습니다.
- 이메일 전송 기능을 구현했습니다.

## ✅ 작업 항목
- [x] 학생회 회원가입 로직을 구현했습니다. 
아이디, 비밀번호를 받아 회원가입하도록 구현했습니다.
JWT를 통해 토큰 발급 시 사용자, 학생회에 역할을 각각 다르게 부여하여 토큰이 발급되도록 하였습니다. 이를 통해 사용자와 학생회 간 구분이 가능합니다.
회원가입 시 이메일 인증이 안되어있거나 이미 가입된 이메일이면 예외처리가 되도록 구현했습니다.
학생회 종류는 총학생회, 단과대 학생회, 과학생회가 있으며 총학생회면 학교 id만 입력, 단과대 학생회면 학교 id와 단과대 id 입력, 과학생회면 전부 입력하도록 구현했습니다.

- [x] 회원가입을 할 경우 작성한 이메일을 인증하는 기능을 구현했습니다. 
이메일로 인증코드를 전송하고 이메일 인증을 하도록 합니다.

## 📸 스크린샷 (선택)

### 이메일 전송 기능
 - 특정 상대에게 이메일을 전송합니다. (illta.campus@gmail.com이 상대방에서 전송합니다.)
<img width="1536" height="911" alt="image" src="https://github.com/user-attachments/assets/e3f58084-502a-47af-9e6a-5a2d2626c617" />

- 이메일로 다음과 같이 인증코드와 함께 메일이 옵니다. 
<img width="800" height="486" alt="image" src="https://github.com/user-attachments/assets/de30738f-91bc-4ca9-ab95-23fbe47a5f84" />

<hr>

### 이메일 인증 기능
- 메일로 받은 인증 코드로 인증요청을 하면 잘 인증이 됩니다.
<img width="1506" height="281" alt="image" src="https://github.com/user-attachments/assets/4794adff-0b7b-4cd3-abda-cdcc9597fc7e" />

<hr>

### 학생회 회원가입 기능
- 다음과 같이 이메일 인증이 된 상태라면 회원가입이 제대로 동작합니다.
<img width="1482" height="464" alt="image" src="https://github.com/user-attachments/assets/52525114-a70e-4b81-854f-d10e32872b2b" />

- 만약 이메일 인증이 되지 않았다면 예외처리
<img width="1482" height="297" alt="image" src="https://github.com/user-attachments/assets/70eee486-5a33-4d2f-8c49-26777426cd94" />



## 📎 참고 이슈
관련 이슈 번호 #7 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 학생회 전용 가입·로그인, 역할 기반 인증 토큰(유저/학생회) 및 가입 시 이메일 인증(발송·확인) 흐름 추가
  * 학교/단과대/학과별 학생회 유형 및 범위 검증, 관련 응답 포맷 및 예외 타입 추가

* **설정/잡무**
  * 메일 전송 라이브러리·설정 추가(개발/로컬/프로덕션 반영), 비밀번호 인코더 빈 등록 및 CORS 허용 원본 확장
  * JPA 감사용 공통 베이스 엔티티 도입

* **문서**
  * 주요 API에 Swagger/OpenAPI 주석 추가하여 문서화 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->