### PR TITLE
Bug/#29 키워드로 장소 검색하는 api 동작 시 반환되는 링크가 유효하지 않은 오류 해결

### DIFF
--- a/src/main/java/com/campus/campus/domain/place/application/dto/response/LikeResponse.java
+++ b/src/main/java/com/campus/campus/domain/place/application/dto/response/LikeResponse.java
@@ -1,5 +1,7 @@
 package com.campus.campus.domain.place.application.dto.response;
 
 public record LikeResponse(
-	Long placeId, boolean liked) {
+	Long placeId,
+	boolean liked
+) {
 }

--- a/src/main/java/com/campus/campus/domain/place/application/dto/response/SavedPlaceInfo.java
+++ b/src/main/java/com/campus/campus/domain/place/application/dto/response/SavedPlaceInfo.java
@@ -33,5 +33,4 @@ public record SavedPlaceInfo(
 	List<String> imgUrls
 
 ) {
-
 }

--- a/src/main/java/com/campus/campus/domain/place/application/dto/response/google/GoogleTextSearchResponse.java
+++ b/src/main/java/com/campus/campus/domain/place/application/dto/response/google/GoogleTextSearchResponse.java
@@ -13,5 +13,3 @@ public record GoogleTextSearchResponse(
 	) {
 	}
 }
-
-

--- a/src/main/java/com/campus/campus/domain/place/application/mapper/PlaceMapper.java
+++ b/src/main/java/com/campus/campus/domain/place/application/mapper/PlaceMapper.java
@@ -21,8 +21,8 @@ public class PlaceMapper {
 		);
 	}
 
-	public SavedPlaceInfo toSavedPlaceInfo(NaverSearchResponse.Item item, String placeName, String placeKey, String naverPlaceUrl, List<String> images) {
-
+	public SavedPlaceInfo toSavedPlaceInfo(NaverSearchResponse.Item item, String placeName, String placeKey,
+		String naverPlaceUrl, List<String> images) {
 		return new SavedPlaceInfo(
 			placeName,
 			placeKey,
@@ -35,9 +35,7 @@ public class PlaceMapper {
 		);
 	}
 
-	public Place createPlace(
-		SavedPlaceInfo savedPlaceInfo, String placeName
-	) {
+	public Place createPlace(SavedPlaceInfo savedPlaceInfo, String placeName) {
 		return Place.builder()
 			.placeKey(savedPlaceInfo.placeKey())
 			.placeName(placeName)
@@ -49,10 +47,7 @@ public class PlaceMapper {
 			.build();
 	}
 
-	public PlaceImages createPlaceImages(
-		String placeKey,
-		String googleImageUrl
-	) {
+	public PlaceImages createPlaceImages(String placeKey, String googleImageUrl) {
 		return PlaceImages.builder()
 			.placeKey(placeKey)
 			.imageUrl(googleImageUrl)

--- a/src/main/java/com/campus/campus/domain/place/application/mapper/PlaceMapper.java
+++ b/src/main/java/com/campus/campus/domain/place/application/mapper/PlaceMapper.java
@@ -1,7 +1,5 @@
 package com.campus.campus.domain.place.application.mapper;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.springframework.stereotype.Component;
@@ -9,7 +7,6 @@ import org.springframework.stereotype.Component;
 import com.campus.campus.domain.place.application.dto.response.LikeResponse;
 import com.campus.campus.domain.place.application.dto.response.SavedPlaceInfo;
 import com.campus.campus.domain.place.application.dto.response.naver.NaverSearchResponse;
-import com.campus.campus.domain.place.application.exception.NaverMapAPIException;
 import com.campus.campus.domain.place.domain.entity.Coordinate;
 import com.campus.campus.domain.place.domain.entity.LikedPlace;
 import com.campus.campus.domain.place.domain.entity.Place;
@@ -18,49 +15,32 @@ import com.campus.campus.domain.user.domain.entity.User;
 
 @Component
 public class PlaceMapper {
-
-	public String buildNaverPlaceUrl(NaverSearchResponse.Item item) {
-		try {
-			return String.format(
-				"https://map.naver.com/v5/search/%s?c=%f,%f,15,0,0,0,dh",
-				URLEncoder.encode(item.title(), StandardCharsets.UTF_8),
-				Double.parseDouble(item.mapy()),
-				Double.parseDouble(item.mapx())
-			);
-		} catch (Exception e) {
-			throw new NaverMapAPIException();
-		}
-	}
-
 	public LikeResponse toLikeResponse(Place place) {
 		return new LikeResponse(
 			place.getPlaceId(), true
 		);
 	}
 
-	public SavedPlaceInfo toSavedPlaceInfo(NaverSearchResponse.Item item, String placeKey, List<String> images) {
+	public SavedPlaceInfo toSavedPlaceInfo(NaverSearchResponse.Item item, String placeName, String placeKey, String naverPlaceUrl, List<String> images) {
 
 		return new SavedPlaceInfo(
-			stripHtml(item.title()),
+			placeName,
 			placeKey,
 			item.address(),
 			item.category(),
-			buildNaverPlaceUrl(item),
+			naverPlaceUrl,
 			item.telephone(),
-			Coordinate.fromNaver(
-				Double.parseDouble(item.mapy()), //위도
-				Double.parseDouble(item.mapx()) //경도
-			),
+			toCoordinate(item),
 			images
 		);
 	}
 
 	public Place createPlace(
-		SavedPlaceInfo savedPlaceInfo
+		SavedPlaceInfo savedPlaceInfo, String placeName
 	) {
 		return Place.builder()
 			.placeKey(savedPlaceInfo.placeKey())
-			.placeName(stripHtml(savedPlaceInfo.placeName()))
+			.placeName(placeName)
 			.placeCategory(savedPlaceInfo.category())
 			.phone(savedPlaceInfo.telephone())
 			.address(savedPlaceInfo.address())
@@ -86,10 +66,10 @@ public class PlaceMapper {
 			.build();
 	}
 
-	/**
-	 * 태그 제거용
-	 */
-	public String stripHtml(String text) {
-		return text.replaceAll("<[^>]*>", "");
+	public Coordinate toCoordinate(NaverSearchResponse.Item item) {
+		return Coordinate.fromNaver(
+			Double.parseDouble(item.mapx()),
+			Double.parseDouble(item.mapy())
+		);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
+++ b/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
@@ -1,5 +1,7 @@
 package com.campus.campus.domain.place.application.service;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 
@@ -10,9 +12,11 @@ import org.springframework.transaction.annotation.Transactional;
 import com.campus.campus.domain.place.application.dto.response.LikeResponse;
 import com.campus.campus.domain.place.application.dto.response.SavedPlaceInfo;
 import com.campus.campus.domain.place.application.dto.response.naver.NaverSearchResponse;
+import com.campus.campus.domain.place.application.exception.NaverMapAPIException;
 import com.campus.campus.domain.place.application.exception.PlaceCreationException;
 import com.campus.campus.domain.place.application.mapper.PlaceMapper;
 import com.campus.campus.domain.place.application.util.PlaceKeyGenerator;
+import com.campus.campus.domain.place.domain.entity.Coordinate;
 import com.campus.campus.domain.place.domain.entity.LikedPlace;
 import com.campus.campus.domain.place.domain.entity.Place;
 import com.campus.campus.domain.place.domain.entity.PlaceImages;
@@ -47,24 +51,70 @@ public class PlaceService {
 
 	public List<SavedPlaceInfo> search(String keyword) {
 		//네이버에서 특정 장소 기본정보 받아오기
-		NaverSearchResponse response = naverMapClient.searchPlaces(keyword, 5);
+		NaverSearchResponse naverSearchResponse = naverMapClient.searchPlaces(keyword, 5);
 
-		return response.items().stream()
+		return naverSearchResponse.items().stream()
 			.map(item -> {
 
-				String name = placeMapper.stripHtml(item.title());
+				String name = stripHtml(item.title());
 				String address = item.roadAddress();
-
-				//placeKey 생성
 				String placeKey = PlaceKeyGenerator.generate(name, address);
+				List<String> placeImages = getPlaceImgs(placeKey, name, address);
+				String naverPlaceUrl = buildNaverPlaceUrl(item);
 
-				//구글 -> 이미지 가져오기
-				List<String> images = getPlaceImgs(placeKey, name, address);
-
-				//이미지도 함께 저장
-				return placeMapper.toSavedPlaceInfo(item, placeKey, images);
+				return placeMapper.toSavedPlaceInfo(item, name, placeKey, naverPlaceUrl, placeImages);
 			})
 			.toList();
+	}
+
+	//장소 저장
+	@Transactional
+	public LikeResponse likePlace(SavedPlaceInfo placeInfo, Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(UserNotFoundException::new);
+
+		String placeKey = placeInfo.placeKey();
+
+		//이미 좋아요가 존재하는지 확인
+		Optional<LikedPlace> likedPlace = likedPlacesRepository.findByUserIdAndPlace_PlaceKey(userId, placeKey);
+
+		if (likedPlace.isPresent()) {
+			//이미 좋아요 상태->좋아요 취소
+			likedPlacesRepository.delete(likedPlace.get());
+			return new LikeResponse(null, false);
+		}
+
+		//Place 엔티티 생성
+		Place place;
+		try {
+			//조회
+			place = placeRepository.findByPlaceKey(placeKey)
+				.orElseGet(() -> {
+					//없으면 생성
+					String placeName = stripHtml(placeInfo.placeName());
+					Place newPlace = placeRepository.save(placeMapper.createPlace(placeInfo, placeName));
+					//신규 생성된 경우에만 이미지 저장
+					migrateImagesToOci(newPlace.getPlaceKey(), placeInfo.imgUrls());
+
+					return newPlace;
+				});
+		} catch (DataIntegrityViolationException e) {
+			//동시 생성으로 unique 제약 위반 시 다시 조회
+			place = placeRepository.findByPlaceKey(placeKey)
+				.orElseThrow(PlaceCreationException::new);
+		}
+		//likedPlace 저장
+		LikedPlace savedLikedPlace = placeMapper.createLikedPlace(user, place);
+		likedPlacesRepository.save(savedLikedPlace);
+
+		return placeMapper.toLikeResponse(place);
+	}
+
+	/**
+	 * 태그 제거용
+	 */
+	private String stripHtml(String text) {
+		return text.replaceAll("<[^>]*>", "");
 	}
 
 	/*
@@ -95,46 +145,34 @@ public class PlaceService {
 			.toList();
 	}
 
-	//장소 저장
-	@Transactional
-	public LikeResponse likePlace(SavedPlaceInfo placeInfo, Long userId) {
-		User user = userRepository.findById(userId)
-			.orElseThrow(UserNotFoundException::new);
-
-		String placeKey = placeInfo.placeKey();
-
-		//이미 좋아요가 존재하는지 확인
-		Optional<LikedPlace> likedPlace = likedPlacesRepository.findByUserIdAndPlace_PlaceKey(userId, placeKey);
-
-		if (likedPlace.isPresent()) {
-			//이미 좋아요 상태->좋아요 취소
-			likedPlacesRepository.delete(likedPlace.get());
-			return new LikeResponse(null, false);
+	private String buildNaverPlaceUrl(NaverSearchResponse.Item item) {
+		String link = item.link();
+		if (link != null && !link.isBlank()) {
+			String normalized = normalizeNaverMapLink(link);
+			if (normalized != null) {
+				return normalized;
+			}
 		}
 
-		//Place 엔티티 생성
-		Place place;
 		try {
-			//조회
-			place = placeRepository.findByPlaceKey(placeKey)
-				.orElseGet(() -> {
-					//없으면 생성
-					Place newPlace = placeRepository.save(placeMapper.createPlace(placeInfo));
-					//신규 생성된 경우에만 이미지 저장
-					migrateImagesToOci(newPlace.getPlaceKey(), placeInfo.imgUrls());
-
-					return newPlace;
-				});
-		} catch (DataIntegrityViolationException e) {
-			//동시 생성으로 unique 제약 위반 시 다시 조회
-			place = placeRepository.findByPlaceKey(placeKey)
-				.orElseThrow(PlaceCreationException::new);
+			Coordinate coordinate = placeMapper.toCoordinate(item);
+			return String.format(
+				"https://map.naver.com/v5/search/%s?c=%f,%f,15,0,0,0,dh",
+				URLEncoder.encode(stripHtml(item.title()), StandardCharsets.UTF_8),
+				coordinate.latitude(),
+				coordinate.longitude()
+			);
+		} catch (Exception e) {
+			throw new NaverMapAPIException();
 		}
-		//likedPlace 저장
-		LikedPlace savedLikedPlace = placeMapper.createLikedPlace(user, place);
-		likedPlacesRepository.save(savedLikedPlace);
+	}
 
-		return placeMapper.toLikeResponse(place);
+	private String normalizeNaverMapLink(String link) {
+		String trimmed = link.trim();
+		if (trimmed.contains("naver.com") || trimmed.contains("naver.me")) {
+			return trimmed.replace("http://", "https://");
+		}
+		return null;
 	}
 
 	private void migrateImagesToOci(String placeKey, List<String> imageUrls) {

--- a/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
+++ b/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
@@ -59,11 +59,7 @@ public class PlaceService {
 				String placeKey = PlaceKeyGenerator.generate(name, address);
 
 				//구글 -> 이미지 가져오기
-				List<String> images = getPlaceImgs(
-					placeKey,
-					name,
-					address
-				);
+				List<String> images = getPlaceImgs(placeKey, name, address);
 
 				//이미지도 함께 저장
 				return placeMapper.toSavedPlaceInfo(item, placeKey, images);
@@ -86,6 +82,7 @@ public class PlaceService {
 		if (googleImageUrls.isEmpty()) {
 			return List.of();
 		}
+
 		return googleImageUrls;
 	}
 
@@ -107,8 +104,7 @@ public class PlaceService {
 		String placeKey = placeInfo.placeKey();
 
 		//이미 좋아요가 존재하는지 확인
-		Optional<LikedPlace> likedPlace =
-			likedPlacesRepository.findByUserIdAndPlace_PlaceKey(userId, placeKey);
+		Optional<LikedPlace> likedPlace = likedPlacesRepository.findByUserIdAndPlace_PlaceKey(userId, placeKey);
 
 		if (likedPlace.isPresent()) {
 			//이미 좋아요 상태->좋아요 취소
@@ -123,11 +119,10 @@ public class PlaceService {
 			place = placeRepository.findByPlaceKey(placeKey)
 				.orElseGet(() -> {
 					//없으면 생성
-					Place newPlace = placeRepository.save(
-						placeMapper.createPlace(placeInfo)
-					);
+					Place newPlace = placeRepository.save(placeMapper.createPlace(placeInfo));
 					//신규 생성된 경우에만 이미지 저장
-					migrateImagestoOci(newPlace.getPlaceKey(), placeInfo.imgUrls());
+					migrateImagesToOci(newPlace.getPlaceKey(), placeInfo.imgUrls());
+
 					return newPlace;
 				});
 		} catch (DataIntegrityViolationException e) {
@@ -142,7 +137,7 @@ public class PlaceService {
 		return placeMapper.toLikeResponse(place);
 	}
 
-	private void migrateImagestoOci(String placeKey, List<String> imageUrls) {
+	private void migrateImagesToOci(String placeKey, List<String> imageUrls) {
 
 		//google 이미지 OCI 업로드
 		for (String googleUrl : imageUrls) {
@@ -151,26 +146,20 @@ public class PlaceService {
 				byte[] bytes = googleClient.downloadImage(googleUrl);
 
 				//OCI 업로드->objectKey 반환
-				PresignedUrlResponseDto presigned =
+				PresignedUrlResponseDto presignedUrlResponseDto =
 					presignedUrlService.createPresignedUrl(
 						"places",
 						new PresignedUrlRequestDto("image/jpeg")
 					);
 
-				presignedUrlService.uploadToOci(
-					presigned.uploadUrl(),
-					bytes,
-					"image/jpeg"
-				);
+				presignedUrlService.uploadToOci(presignedUrlResponseDto.uploadUrl(), bytes, "image/jpeg");
 
-				placeImagesRepository.save(
-					placeMapper.createPlaceImages(placeKey, presigned.imageUrl())
-				);
+				PlaceImages placeImages = placeMapper.createPlaceImages(placeKey, presignedUrlResponseDto.imageUrl());
+				placeImagesRepository.save(placeImages);
 			} catch (Exception e) {
 				log.warn("이미지를 OCI에 업로드하여 저장하는 것을 실패했어요. placeKey={},imageUrl={}", placeKey, googleUrl, e);
 			}
 
 		}
 	}
-
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,7 +13,7 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
         default_batch_fetch_size: 100
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
   mail:
     host: smtp.gmail.com
     port: 587


### PR DESCRIPTION
## 🔀 변경 내용
- 키워드로 장소 검색하는 api 동작 시 반환되는 링크로 접속 시 제대로 네이버 지도로 연결되도록 수정했습니다.
- 장소 링크를 생성하는 로직을 PlaceMapper -> PlaceService로 위치를 옮겼습니다.

## ✅ 작업 항목
- [x] link가 제대로 반환되도록 수정했습니다. 
- [x] 장소 링크 생성 로직 PlaceMapper -> PlaceService 이동 

**기존 방식**: 검색 URL을 직접 조립하던 방식
URLEncoder.encode(item.title())로 태그 포함한 문자열을 그대로 인코딩해서 검색어로 던졌으며, 이럴 경우 검색 정확도가 떨어질 수 있다.
Double.parseDouble(item.mapx()) 그대로 URL에 넣었다. → 1269873882 같은 값이 들어가서 지도 중심이 말이 안 되게 잡힐 수 있다.

**수정 방식**: 네이버에서 내린 item.link()를 우선 사용하며 fallback(직접 조립) 시 좌표/타이틀 가공 방법 수정
URL 조립에서 stripHtml(item.title())를 써서 실제 장소명만 검색어로 사용하여 원하는 검색 결과 페이지로 이동한다.
Coordinate.fromNaver(mapx, mapy)로 / 10_000_000.0 변환 후 사용한다. → 중심 좌표가 현실적인 값으로 들어간다.

## 📸 스크린샷 (선택)
- 만약 다음과 같이 특정 장소에 대한 링크가 반환되어 해당 링크로 접속할 경우 다음과 같이 제대로 이동되는 것을 확인할 수 있습니다.
<img width="1459" height="592" alt="image" src="https://github.com/user-attachments/assets/ebb1c6dd-1f87-4ef3-be3f-39e6141d6225" />
<img width="1795" height="1011" alt="image" src="https://github.com/user-attachments/assets/8003f4d3-8a47-4d85-b240-d593059c7c0a" />



## 📎 참고 이슈
관련 이슈 번호 #29 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  - 코드 포맷팅 및 레이아웃 정리

* **Refactor**
  - 장소 검색 및 저장 처리 흐름 내부 구조 개선
  - 데이터 저장 방식 설정 변경 (스키마 자동 생성에서 업데이트 모드로)
  - URL 및 이미지 처리 로직 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->