### PR TITLE
Feat/#38 학생회 비밀번호 찾기 id, email 검증 로직 구현

### DIFF
--- a/src/main/java/com/campus/campus/domain/council/application/dto/request/ValidateEmailToFindPasswordRequest.java
+++ b/src/main/java/com/campus/campus/domain/council/application/dto/request/ValidateEmailToFindPasswordRequest.java
@@ -1,0 +1,15 @@
+package com.campus.campus.domain.council.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record ValidateEmailToFindPasswordRequest(
+	@Schema(description = "회원가입 id", example = "dede1234")
+	@NotBlank
+	String loginId,
+
+	@Schema(description = "인증 이메일", example = "campus@campus.com")
+	@NotBlank
+	String email
+) {
+}

--- a/src/main/java/com/campus/campus/domain/council/application/dto/request/ValidateIdToFindPasswordRequest.java
+++ b/src/main/java/com/campus/campus/domain/council/application/dto/request/ValidateIdToFindPasswordRequest.java
@@ -1,0 +1,11 @@
+package com.campus.campus.domain.council.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record ValidateIdToFindPasswordRequest(
+	@Schema(description = "회원가입 id", example = "dede1234")
+	@NotBlank
+	String loginId
+) {
+}

--- a/src/main/java/com/campus/campus/domain/council/application/service/CouncilLoginService.java
+++ b/src/main/java/com/campus/campus/domain/council/application/service/CouncilLoginService.java
@@ -12,6 +12,8 @@ import com.campus.campus.domain.council.application.dto.request.StudentCouncilLo
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilLoginRequest;
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilSignUpRequest;
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilWithdrawRequest;
+import com.campus.campus.domain.council.application.dto.request.ValidateEmailToFindPasswordRequest;
+import com.campus.campus.domain.council.application.dto.request.ValidateIdToFindPasswordRequest;
 import com.campus.campus.domain.council.application.dto.response.StudentCouncilFindIdResponse;
 import com.campus.campus.domain.council.application.dto.response.StudentCouncilLoginResponse;
 import com.campus.campus.domain.council.application.exception.CouncilIdAndVerifiedEmailInvalidException;
@@ -158,6 +160,23 @@ public class CouncilLoginService {
 		emailVerification.use();
 
 		studentCouncilRepository.save(studentCouncil);
+	}
+
+	public void validateIdToFindPassword(ValidateIdToFindPasswordRequest validateIdToFindPasswordRequest) {
+		if (!studentCouncilRepository.existsByLoginIdAndManagerApprovedIsTrueAndDeletedAtIsNull(
+			validateIdToFindPasswordRequest.loginId())) {
+			throw new StudentCouncilNotFoundException();
+		}
+	}
+
+	public void validateEmailToFindPassword(ValidateEmailToFindPasswordRequest validateEmailToFindPasswordRequest) {
+		StudentCouncil studentCouncil = studentCouncilRepository
+			.findByLoginIdAndManagerApprovedIsTrueAndDeletedAtIsNull(validateEmailToFindPasswordRequest.loginId())
+			.orElseThrow(StudentCouncilNotFoundException::new);
+
+		if (!studentCouncil.getEmail().equals(validateEmailToFindPasswordRequest.email())) {
+			throw new CouncilIdAndVerifiedEmailInvalidException();
+		}
 	}
 
 	@Transactional

--- a/src/main/java/com/campus/campus/domain/council/domain/repository/StudentCouncilRepository.java
+++ b/src/main/java/com/campus/campus/domain/council/domain/repository/StudentCouncilRepository.java
@@ -42,4 +42,6 @@ public interface StudentCouncilRepository extends JpaRepository<StudentCouncil, 
 	boolean existsByIdAndManagerApprovedIsTrueAndDeletedAtIsNull(Long councilId);
 
 	boolean existsByEmailAndDeletedAtIsNotNull(String email);
+
+	boolean existsByLoginIdAndManagerApprovedIsTrueAndDeletedAtIsNull(String loginId);
 }

--- a/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilLoginController.java
+++ b/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilLoginController.java
@@ -14,6 +14,8 @@ import com.campus.campus.domain.council.application.dto.request.StudentCouncilLo
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilLoginRequest;
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilSignUpRequest;
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilWithdrawRequest;
+import com.campus.campus.domain.council.application.dto.request.ValidateEmailToFindPasswordRequest;
+import com.campus.campus.domain.council.application.dto.request.ValidateIdToFindPasswordRequest;
 import com.campus.campus.domain.council.application.dto.response.StudentCouncilFindIdResponse;
 import com.campus.campus.domain.council.application.dto.response.StudentCouncilLoginResponse;
 import com.campus.campus.domain.council.application.service.CouncilLoginService;
@@ -71,6 +73,24 @@ public class StudentCouncilLoginController {
 		councilLoginService.findPassword(studentCouncilFindPasswordRequest);
 
 		return CommonResponse.success(StudentCouncilResponseCode.FIND_PASSWORD_SUCCESS);
+	}
+
+	@PostMapping("/find/password/validate/id")
+	@Operation(summary = "비밀번호 찾기 아이디 검증")
+	public CommonResponse<Void> validateLoginIdToFindPassword(
+		@Valid @RequestBody ValidateIdToFindPasswordRequest validateIdToFindPasswordRequest) {
+		councilLoginService.validateIdToFindPassword(validateIdToFindPasswordRequest);
+
+		return CommonResponse.success(StudentCouncilResponseCode.VALIDATE_LOGIN_ID_SUCCESS);
+	}
+
+	@PostMapping("/find/password/validate/email")
+	@Operation(summary = "비밀번호 찾기 이메일 검증")
+	public CommonResponse<Void> validateEmailToFindPassword(
+		@Valid @RequestBody ValidateEmailToFindPasswordRequest validateEmailToFindPasswordRequest) {
+		councilLoginService.validateEmailToFindPassword(validateEmailToFindPasswordRequest);
+
+		return CommonResponse.success(StudentCouncilResponseCode.VALIDATE_EMAIL_SUCCESS);
 	}
 
 	@PatchMapping("/withdraw")

--- a/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilResponseCode.java
@@ -11,9 +11,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum StudentCouncilResponseCode implements ResponseCodeInterface {
 	SIGNUP_REQUEST_SUCCESS(200, HttpStatus.OK, "학생회 회원가입 요청에 성공했습니다."),
-	VALIDATE_LOGIN_ID_SUCCESS(200, HttpStatus.OK, "회원가입 로그인 id 중복 검증에 성공했습니다."),
+	VALIDATE_LOGIN_ID_SUCCESS(200, HttpStatus.OK, "로그인 id 검증에 성공했습니다."),
 	LOGIN_SUCCESS(200, HttpStatus.OK, "학생회 로그인에 성공했습니다."),
 	FIND_ID_SUCCESS(200, HttpStatus.OK, "아이디 찾기에 성공했습니다."),
+	VALIDATE_EMAIL_SUCCESS(200, HttpStatus.OK, "이메일 검증에 성공했습니다."),
 	FIND_PASSWORD_SUCCESS(200, HttpStatus.OK, "비밀번호 재설정에 성공했습니다."),
 	CHANGE_EMAIL_SUCCESS(200, HttpStatus.OK, "이메일 변경에 성공했습니다."),
 	CHANGE_PASSWORD_SUCCESS(200, HttpStatus.OK, "비밀번호 변경에 성공했습니다."),

--- a/src/main/java/com/campus/campus/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/campus/campus/global/config/PermitUrlConfig.java
@@ -16,6 +16,8 @@ public class PermitUrlConfig {
 			"/auth/council/login",
 			"/auth/council/find/id",
 			"/auth/council/find/password",
+			"/auth/council/find/password/validate/id",
+			"/auth/council/find/password/validate/email",
 			"/auth/council/signup/email/code",
 			"/auth/council/signup/email/code/verify",
 			"/auth/council/find/id/email/code",


### PR DESCRIPTION
## 🔀 변경 내용
- 학생회 비밀번호 찾기 id, email 검증 로직 구현했습니다.

## ✅ 작업 항목
- [x] 학생회 비밀번호 찾기 id 검증 로직 구현
- [x] 학생회 비밀번호 찾기 email 검증 로직 구현

## 📸 스크린샷 (선택)
### id 검증 로직
<img width="1485" height="915" alt="image" src="https://github.com/user-attachments/assets/e30b3bf9-ef26-4446-985d-19fc37f3a039" />

### email 검증 로직
<img width="1455" height="927" alt="image" src="https://github.com/user-attachments/assets/54b93e49-733d-478b-a006-4ca3b750657b" />

## 📎 참고 이슈
관련 이슈 번호 #38 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 비밀번호 찾기 기능에 로그인 ID 및 이메일 검증 단계 추가
  * 두 가지 단계별 검증 프로세스로 비밀번호 복구 보안 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->