### PR TITLE
Feat/#42 학생회 게시글 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetLikedPostResponse.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetLikedPostResponse.java
@@ -1,0 +1,23 @@
+package com.campus.campus.domain.councilpost.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GetLikedPostResponse(
+	@Schema(description = "게시글 id", example = "1")
+	Long postId,
+
+	@Schema(description = "게시글 이름", example = "투썸 제휴")
+	String title,
+
+	@Schema(description = "게시글 장소", example = "투썸 플레이스")
+	String place,
+
+	@Schema(description = "시간(끝나는 시간 or 행사날짜)", example = "2026-01-10T18:00:00")
+	LocalDateTime dateTime,
+
+	@Schema(description = "썸네일 image url", example = "https://www.example.com.png")
+	String thumbnailImageUrl
+) {
+}

--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetPostForUserResponse.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetPostForUserResponse.java
@@ -12,7 +12,7 @@ import lombok.Builder;
 
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record GetPostResponseForUser(
+public record GetPostForUserResponse(
 
 	Long id,
 	Long writerId,

--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetPostResponse.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetPostResponse.java
@@ -12,7 +12,7 @@ import lombok.Builder;
 
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record PostResponse(
+public record GetPostResponse(
 
 	Long id,
 	Long writerId,

--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetPostResponseForUser.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetPostResponseForUser.java
@@ -1,0 +1,36 @@
+package com.campus.campus.domain.councilpost.application.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.campus.campus.domain.councilpost.domain.entity.PostCategory;
+import com.campus.campus.domain.councilpost.domain.entity.ThumbnailIcon;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record GetPostResponseForUser(
+
+	Long id,
+	Long writerId,
+	String writerName,
+
+	PostCategory category,
+	String title,
+	String content,
+	String place,
+	LocalDate startDate,
+	LocalDate endDate,
+	LocalDateTime startDateTime,
+
+	String thumbnailImageUrl,
+	ThumbnailIcon thumbnailIcon,
+
+	boolean isLiked,
+
+	List<String> images
+) {
+}

--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/LikePostResponse.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/LikePostResponse.java
@@ -3,13 +3,13 @@ package com.campus.campus.domain.councilpost.application.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record LikePostResponse(
-	@Schema(name = "좋아요 누른 사용자 id", example = "1")
+	@Schema(description = "좋아요 누른 사용자 id", example = "1")
 	Long userId,
 
-	@Schema(name = "좋아요 누를 게시글의 id", example = "1")
+	@Schema(description = "좋아요 누를 게시글의 id", example = "1")
 	Long postId,
 
-	@Schema(name = "좋아요 여부", example = "true")
+	@Schema(description = "좋아요 여부", example = "true")
 	boolean liked
 ) {
 }

--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/LikePostResponse.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/LikePostResponse.java
@@ -9,7 +9,7 @@ public record LikePostResponse(
 	@Schema(name = "좋아요 누를 게시글의 id", example = "1")
 	Long postId,
 
-	@Schema(name = "좋아요 여부", example = "example")
+	@Schema(name = "좋아요 여부", example = "true")
 	boolean liked
 ) {
 }

--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/LikePostResponse.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/LikePostResponse.java
@@ -1,0 +1,15 @@
+package com.campus.campus.domain.councilpost.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LikePostResponse(
+	@Schema(name = "좋아요 누른 사용자 id", example = "1")
+	Long userId,
+
+	@Schema(name = "좋아요 누를 게시글의 id", example = "1")
+	Long postId,
+
+	@Schema(name = "좋아요 여부", example = "example")
+	boolean liked
+) {
+}

--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/PostListItemResponse.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/PostListItemResponse.java
@@ -13,6 +13,7 @@ public record PostListItemResponse(
 	LocalDateTime endDateTime,
 	String thumbnailImageUrl,
 	ThumbnailIcon thumbnailIcon,
-	Boolean isWriter
+	Boolean isWriter,
+	boolean liked
 ) {
 }

--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/PostListItemResponse.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/PostListItemResponse.java
@@ -13,7 +13,6 @@ public record PostListItemResponse(
 	LocalDateTime endDateTime,
 	String thumbnailImageUrl,
 	ThumbnailIcon thumbnailIcon,
-	Boolean isWriter,
 	boolean liked
 ) {
 }

--- a/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
@@ -7,11 +7,14 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
+import com.campus.campus.domain.councilpost.application.dto.response.LikePostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.PostListItemResponse;
 import com.campus.campus.domain.councilpost.application.dto.request.PostRequest;
 import com.campus.campus.domain.councilpost.application.dto.response.PostResponse;
+import com.campus.campus.domain.councilpost.domain.entity.LikePost;
 import com.campus.campus.domain.councilpost.domain.entity.PostImage;
 import com.campus.campus.domain.councilpost.domain.entity.StudentCouncilPost;
+import com.campus.campus.domain.user.domain.entity.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -59,8 +62,16 @@ public class StudentCouncilPostMapper {
 		return builder.build();
 	}
 
-	public StudentCouncilPost createStudentCouncilPost(StudentCouncil writer, PostRequest dto, LocalDateTime startDateTime,
-		LocalDateTime endDateTime) {
+	public LikePostResponse toLikePostResponse(User user, StudentCouncilPost post, boolean liked) {
+		return new LikePostResponse(
+			user.getId(),
+			post.getId(),
+			liked
+		);
+	}
+
+	public StudentCouncilPost createStudentCouncilPost(StudentCouncil writer, PostRequest dto,
+		LocalDateTime startDateTime, LocalDateTime endDateTime) {
 		return StudentCouncilPost.builder()
 			.writer(writer)
 			.category(dto.category())
@@ -78,6 +89,13 @@ public class StudentCouncilPostMapper {
 		return PostImage.builder()
 			.post(post)
 			.imageUrl(imageUrl)
+			.build();
+	}
+
+	public LikePost createLikePost(User user, StudentCouncilPost post) {
+		return LikePost.builder()
+			.post(post)
+			.user(user)
 			.build();
 	}
 }

--- a/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
@@ -26,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class StudentCouncilPostMapper {
-	public PostListItemResponse toPostListItemResponse(StudentCouncilPost post, Long councilId, boolean isLiked) {
+	public PostListItemResponse toPostListItemResponse(StudentCouncilPost post, boolean isLiked) {
 		return new PostListItemResponse(
 			post.getId(),
 			post.getCategory(),
@@ -35,7 +35,6 @@ public class StudentCouncilPostMapper {
 			post.isEvent() ? post.getStartDateTime() : post.getEndDateTime(),
 			post.getThumbnailImageUrl(),
 			post.getThumbnailIcon(),
-			post.isWrittenByCouncil(councilId),
 			isLiked
 		);
 	}

--- a/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
@@ -15,7 +15,7 @@ import com.campus.campus.domain.councilpost.application.dto.response.GetUpcoming
 import com.campus.campus.domain.councilpost.application.dto.response.GetActivePartnershipListForUserResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.PostListItemResponse;
 import com.campus.campus.domain.councilpost.application.dto.request.PostRequest;
-import com.campus.campus.domain.councilpost.application.dto.response.GetPostResponseForUser;
+import com.campus.campus.domain.councilpost.application.dto.response.GetPostForUserResponse;
 import com.campus.campus.domain.councilpost.domain.entity.LikePost;
 import com.campus.campus.domain.councilpost.domain.entity.PostImage;
 import com.campus.campus.domain.councilpost.domain.entity.StudentCouncilPost;
@@ -97,10 +97,10 @@ public class StudentCouncilPostMapper {
 		return builder.build();
 	}
 
-	public GetPostResponseForUser toGetPostResponseForUser(StudentCouncilPost post, List<String> images,
+	public GetPostForUserResponse toGetPostForUserResponse(StudentCouncilPost post, List<String> images,
 		Long currentUserId, boolean isLiked) {
 		var writer = post.getWriter();
-		var builder = GetPostResponseForUser.builder()
+		var builder = GetPostForUserResponse.builder()
 			.id(post.getId())
 			.writerId(writer.getId())
 			.writerName(writer.getCouncilName())

--- a/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
@@ -8,13 +8,14 @@ import org.springframework.stereotype.Component;
 
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.councilpost.application.dto.response.GetLikedPostResponse;
+import com.campus.campus.domain.councilpost.application.dto.response.GetPostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.LikePostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.GetPostListForCouncilResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.GetUpcomingEventListForCouncilResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.GetActivePartnershipListForUserResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.PostListItemResponse;
 import com.campus.campus.domain.councilpost.application.dto.request.PostRequest;
-import com.campus.campus.domain.councilpost.application.dto.response.PostResponse;
+import com.campus.campus.domain.councilpost.application.dto.response.GetPostResponseForUser;
 import com.campus.campus.domain.councilpost.domain.entity.LikePost;
 import com.campus.campus.domain.councilpost.domain.entity.PostImage;
 import com.campus.campus.domain.councilpost.domain.entity.StudentCouncilPost;
@@ -71,19 +72,45 @@ public class StudentCouncilPostMapper {
 		);
 	}
 
-	public PostResponse toPostResponse(StudentCouncilPost post, List<String> images, Long currentUserId) {
+	public GetPostResponse toGetPostResponse(StudentCouncilPost post, List<String> images, Long currentCouncilId) {
 		var writer = post.getWriter();
-		var builder = PostResponse.builder()
+		var builder = GetPostResponse.builder()
 			.id(post.getId())
 			.writerId(writer.getId())
 			.writerName(writer.getCouncilName())
-			.isWriter(post.isWrittenByCouncil(currentUserId))
+			.isWriter(post.isWrittenByCouncil(currentCouncilId))
 			.category(post.getCategory())
 			.title(post.getTitle())
 			.content(post.getContent())
 			.place(post.getPlace())
 			.thumbnailImageUrl(post.getThumbnailImageUrl())
 			.thumbnailIcon(post.getThumbnailIcon())
+			.images(images != null ? images : Collections.emptyList());
+
+		if (post.isEvent()) {
+			builder.startDateTime(post.getStartDateTime());
+		} else {
+			builder.startDate(post.getDisplayStartDate());
+			builder.endDate(post.getDisplayEndDate());
+		}
+
+		return builder.build();
+	}
+
+	public GetPostResponseForUser toGetPostResponseForUser(StudentCouncilPost post, List<String> images,
+		Long currentUserId, boolean isLiked) {
+		var writer = post.getWriter();
+		var builder = GetPostResponseForUser.builder()
+			.id(post.getId())
+			.writerId(writer.getId())
+			.writerName(writer.getCouncilName())
+			.category(post.getCategory())
+			.title(post.getTitle())
+			.content(post.getContent())
+			.place(post.getPlace())
+			.thumbnailImageUrl(post.getThumbnailImageUrl())
+			.thumbnailIcon(post.getThumbnailIcon())
+			.isLiked(isLiked)
 			.images(images != null ? images : Collections.emptyList());
 
 		if (post.isEvent()) {

--- a/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
@@ -25,19 +25,17 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class StudentCouncilPostMapper {
-
-	public PostListItemResponse toPostListItemResponse(StudentCouncilPost post, Long councilId) {
+	public PostListItemResponse toPostListItemResponse(StudentCouncilPost post, Long councilId, boolean isLiked) {
 		return new PostListItemResponse(
 			post.getId(),
 			post.getCategory(),
 			post.getTitle(),
 			post.getPlace(),
-			post.isEvent()
-				? post.getStartDateTime()
-				: post.getEndDateTime(),
+			post.isEvent() ? post.getStartDateTime() : post.getEndDateTime(),
 			post.getThumbnailImageUrl(),
 			post.getThumbnailIcon(),
-			post.isWrittenByCouncil(councilId)
+			post.isWrittenByCouncil(councilId),
+			isLiked
 		);
 	}
 

--- a/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
+import com.campus.campus.domain.councilpost.application.dto.response.GetLikedPostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.LikePostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.PostListItemResponse;
 import com.campus.campus.domain.councilpost.application.dto.request.PostRequest;
@@ -67,6 +68,16 @@ public class StudentCouncilPostMapper {
 			user.getId(),
 			post.getId(),
 			liked
+		);
+	}
+
+	public GetLikedPostResponse toGetLikedPostResponse(StudentCouncilPost post) {
+		return new GetLikedPostResponse(
+			post.getId(),
+			post.getTitle(),
+			post.getPlace(),
+			post.isEvent() ? post.getStartDateTime() : post.getEndDateTime(),
+			post.getThumbnailImageUrl()
 		);
 	}
 

--- a/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
@@ -2,8 +2,10 @@ package com.campus.campus.domain.councilpost.application.service;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -87,6 +89,23 @@ public class StudentCouncilPostForUserService {
 		);
 	}
 
+	public PostResponse findById(Long postId, Long userId) {
+		User user = userRepository.findByIdWithAcademicInfo(userId).orElseThrow(UserNotFoundException::new);
+
+		StudentCouncilPost post = studentCouncilPostRepository.findByIdWithFullInfo(postId)
+			.orElseThrow(PostNotFoundException::new);
+
+		// 권한 검증
+		postAccessPolicy.validateAccess(user, post.getWriter());
+
+		List<String> imageUrls = postImageRepository.findAllByPostOrderByIdAsc(post)
+			.stream()
+			.map(PostImage::getImageUrl)
+			.toList();
+
+		return studentCouncilPostMapper.toPostResponse(post, imageUrls, userId);
+	}
+
 	public Page<PostListItemResponse> findSchoolPosts(PostCategory category, int page, int size, Long userId) {
 		User user = userRepository.findByIdWithAcademicInfo(userId).orElseThrow(UserNotFoundException::new);
 
@@ -95,7 +114,7 @@ public class StudentCouncilPostForUserService {
 		Page<StudentCouncilPost> posts = studentCouncilPostRepository
 			.findBySchoolId(user.getSchool().getSchoolId(), category, CouncilType.SCHOOL_COUNCIL, pageable);
 
-		return posts.map(post -> studentCouncilPostMapper.toPostListItemResponse(post, userId));
+		return mapPostsWithLikes(posts, userId);
 	}
 
 	public Page<PostListItemResponse> findCollegePosts(PostCategory category, int page, int size, Long userId) {
@@ -110,7 +129,7 @@ public class StudentCouncilPostForUserService {
 		Page<StudentCouncilPost> posts = studentCouncilPostRepository
 			.findByCollegeId(user.getCollege().getCollegeId(), category, CouncilType.COLLEGE_COUNCIL, pageable);
 
-		return posts.map(post -> studentCouncilPostMapper.toPostListItemResponse(post, userId));
+		return mapPostsWithLikes(posts, userId);
 	}
 
 	public Page<PostListItemResponse> findMajorPosts(PostCategory category, int page, int size, Long userId) {
@@ -121,7 +140,7 @@ public class StudentCouncilPostForUserService {
 		Page<StudentCouncilPost> posts = studentCouncilPostRepository
 			.findByMajorId(user.getMajor().getMajorId(), category, CouncilType.MAJOR_COUNCIL, pageable);
 
-		return posts.map(post -> studentCouncilPostMapper.toPostListItemResponse(post, userId));
+		return mapPostsWithLikes(posts, userId);
 	}
 
 	public Page<PostListItemResponse> findUpcomingSchoolEvents72h(int page, int size, Long userId) {
@@ -141,7 +160,7 @@ public class StudentCouncilPostForUserService {
 			pageable
 		);
 
-		return posts.map(post -> studentCouncilPostMapper.toPostListItemResponse(post, userId));
+		return mapPostsWithLikes(posts, userId);
 	}
 
 	public Page<PostListItemResponse> findUpcomingCollegeEvents72h(int page, int size, Long userId) {
@@ -169,7 +188,7 @@ public class StudentCouncilPostForUserService {
 			pageable
 		);
 
-		return posts.map(post -> studentCouncilPostMapper.toPostListItemResponse(post, userId));
+		return mapPostsWithLikes(posts, userId);
 	}
 
 	public Page<PostListItemResponse> findUpcomingMajorEvents72h(int page, int size, Long userId) {
@@ -197,24 +216,7 @@ public class StudentCouncilPostForUserService {
 			pageable
 		);
 
-		return posts.map(post -> studentCouncilPostMapper.toPostListItemResponse(post, userId));
-	}
-
-	public PostResponse findById(Long postId, Long userId) {
-		User user = userRepository.findByIdWithAcademicInfo(userId).orElseThrow(UserNotFoundException::new);
-
-		StudentCouncilPost post = studentCouncilPostRepository.findByIdWithFullInfo(postId)
-			.orElseThrow(PostNotFoundException::new);
-
-		// 권한 검증
-		postAccessPolicy.validateAccess(user, post.getWriter());
-
-		List<String> imageUrls = postImageRepository.findAllByPostOrderByIdAsc(post)
-			.stream()
-			.map(PostImage::getImageUrl)
-			.toList();
-
-		return studentCouncilPostMapper.toPostResponse(post, imageUrls, userId);
+		return mapPostsWithLikes(posts, userId);
 	}
 
 	public List<GetActivePartnershipListForUserResponse> findActivePartnershipForUser(CouncilType councilType,
@@ -253,5 +255,21 @@ public class StudentCouncilPostForUserService {
 		return partnerships.stream()
 			.map(studentCouncilPostMapper::toGetActivePartnershipListForUserResponse)
 			.toList();
+	}
+
+	private Page<PostListItemResponse> mapPostsWithLikes(Page<StudentCouncilPost> posts, Long userId) {
+		List<Long> postIds = posts.getContent().stream()
+			.map(StudentCouncilPost::getId)
+			.toList();
+
+		if (postIds.isEmpty()) {
+			return posts.map(post -> studentCouncilPostMapper.toPostListItemResponse(post, userId, false));
+		}
+
+		Set<Long> likedPostIds = new HashSet<>(likePostRepository.findLikedPostIds(userId, postIds));
+
+		return posts.map(post ->
+			studentCouncilPostMapper.toPostListItemResponse(post, userId, likedPostIds.contains(post.getId()))
+		);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
@@ -265,13 +265,13 @@ public class StudentCouncilPostForUserService {
 			.toList();
 
 		if (postIds.isEmpty()) {
-			return posts.map(post -> studentCouncilPostMapper.toPostListItemResponse(post, userId, false));
+			return posts.map(post -> studentCouncilPostMapper.toPostListItemResponse(post, false));
 		}
 
 		Set<Long> likedPostIds = new HashSet<>(likePostRepository.findLikedPostIds(userId, postIds));
 
 		return posts.map(post ->
-			studentCouncilPostMapper.toPostListItemResponse(post, userId, likedPostIds.contains(post.getId()))
+			studentCouncilPostMapper.toPostListItemResponse(post, likedPostIds.contains(post.getId()))
 		);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
@@ -19,7 +19,7 @@ import com.campus.campus.domain.councilpost.application.dto.response.GetActivePa
 import com.campus.campus.domain.councilpost.application.dto.response.GetLikedPostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.LikePostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.PostListItemResponse;
-import com.campus.campus.domain.councilpost.application.dto.response.GetPostResponseForUser;
+import com.campus.campus.domain.councilpost.application.dto.response.GetPostForUserResponse;
 import com.campus.campus.domain.councilpost.application.exception.CollegeNotSetException;
 import com.campus.campus.domain.councilpost.application.exception.MajorNotSetException;
 import com.campus.campus.domain.councilpost.application.exception.PostNotFoundException;
@@ -89,7 +89,7 @@ public class StudentCouncilPostForUserService {
 		);
 	}
 
-	public GetPostResponseForUser findById(Long postId, Long userId) {
+	public GetPostForUserResponse findById(Long postId, Long userId) {
 		User user = userRepository.findByIdWithAcademicInfo(userId).orElseThrow(UserNotFoundException::new);
 
 		StudentCouncilPost post = studentCouncilPostRepository.findByIdWithFullInfo(postId)
@@ -105,7 +105,7 @@ public class StudentCouncilPostForUserService {
 
 		boolean isLiked = likePostRepository.existsByUserIdAndPost_Id(userId, postId);
 
-		return studentCouncilPostMapper.toGetPostResponseForUser(post, imageUrls, userId, isLiked);
+		return studentCouncilPostMapper.toGetPostForUserResponse(post, imageUrls, userId, isLiked);
 	}
 
 	public Page<PostListItemResponse> findSchoolPosts(PostCategory category, int page, int size, Long userId) {

--- a/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -62,18 +63,17 @@ public class StudentCouncilPostForUserService {
 		StudentCouncilPost post = studentCouncilPostRepository.findById(postId)
 			.orElseThrow(PostNotFoundException::new);
 
-		Optional<LikePost> likePost = likePostRepository.findByUserIdAndPost_Id(userId, postId);
-		boolean isLike;
-		if (likePost.isPresent()) {
-			likePostRepository.delete(likePost.get());
-			isLike = false;
-		} else {
-			LikePost newLikePost = studentCouncilPostMapper.createLikePost(user, post);
-			likePostRepository.save(newLikePost);
-			isLike = true;
+		int deleted = likePostRepository.deleteByUserIdAndPostId(userId, postId);
+		if (deleted > 0) {
+			return studentCouncilPostMapper.toLikePostResponse(user, post, false);
 		}
 
-		return studentCouncilPostMapper.toLikePostResponse(user, post, isLike);
+		try {
+			likePostRepository.saveAndFlush(studentCouncilPostMapper.createLikePost(user, post));
+			return studentCouncilPostMapper.toLikePostResponse(user, post, true);
+		} catch (DataIntegrityViolationException e) {
+			return studentCouncilPostMapper.toLikePostResponse(user, post, true);
+		}
 	}
 
 	public Page<GetLikedPostResponse> findLikedPosts(PostCategory category, int page, int size, Long userId) {

--- a/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
@@ -19,7 +19,7 @@ import com.campus.campus.domain.councilpost.application.dto.response.GetActivePa
 import com.campus.campus.domain.councilpost.application.dto.response.GetLikedPostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.LikePostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.PostListItemResponse;
-import com.campus.campus.domain.councilpost.application.dto.response.PostResponse;
+import com.campus.campus.domain.councilpost.application.dto.response.GetPostResponseForUser;
 import com.campus.campus.domain.councilpost.application.exception.CollegeNotSetException;
 import com.campus.campus.domain.councilpost.application.exception.MajorNotSetException;
 import com.campus.campus.domain.councilpost.application.exception.PostNotFoundException;
@@ -89,7 +89,7 @@ public class StudentCouncilPostForUserService {
 		);
 	}
 
-	public PostResponse findById(Long postId, Long userId) {
+	public GetPostResponseForUser findById(Long postId, Long userId) {
 		User user = userRepository.findByIdWithAcademicInfo(userId).orElseThrow(UserNotFoundException::new);
 
 		StudentCouncilPost post = studentCouncilPostRepository.findByIdWithFullInfo(postId)
@@ -103,7 +103,9 @@ public class StudentCouncilPostForUserService {
 			.map(PostImage::getImageUrl)
 			.toList();
 
-		return studentCouncilPostMapper.toPostResponse(post, imageUrls, userId);
+		boolean isLiked = likePostRepository.existsByUserIdAndPost_Id(userId, postId);
+
+		return studentCouncilPostMapper.toGetPostResponseForUser(post, imageUrls, userId, isLiked);
 	}
 
 	public Page<PostListItemResponse> findSchoolPosts(PostCategory category, int page, int size, Long userId) {

--- a/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
@@ -3,6 +3,7 @@ package com.campus.campus.domain.councilpost.application.service;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -13,15 +14,19 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.campus.campus.domain.council.domain.entity.CouncilType;
 import com.campus.campus.domain.councilpost.application.dto.response.GetActivePartnershipListForUserResponse;
+import com.campus.campus.domain.councilpost.application.dto.response.GetLikedPostResponse;
+import com.campus.campus.domain.councilpost.application.dto.response.LikePostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.PostListItemResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.PostResponse;
 import com.campus.campus.domain.councilpost.application.exception.CollegeNotSetException;
 import com.campus.campus.domain.councilpost.application.exception.MajorNotSetException;
 import com.campus.campus.domain.councilpost.application.exception.PostNotFoundException;
 import com.campus.campus.domain.councilpost.application.mapper.StudentCouncilPostMapper;
+import com.campus.campus.domain.councilpost.domain.entity.LikePost;
 import com.campus.campus.domain.councilpost.domain.entity.PostCategory;
 import com.campus.campus.domain.councilpost.domain.entity.PostImage;
 import com.campus.campus.domain.councilpost.domain.entity.StudentCouncilPost;
+import com.campus.campus.domain.councilpost.domain.repository.LikePostRepository;
 import com.campus.campus.domain.councilpost.domain.repository.PostImageRepository;
 import com.campus.campus.domain.councilpost.domain.repository.StudentCouncilPostRepository;
 import com.campus.campus.domain.councilpost.policy.PostAccessPolicy;
@@ -42,9 +47,45 @@ public class StudentCouncilPostForUserService {
 	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 	private final StudentCouncilPostRepository studentCouncilPostRepository;
 	private final PostImageRepository postImageRepository;
+	private final LikePostRepository likePostRepository;
 	private final StudentCouncilPostMapper studentCouncilPostMapper;
 	private final UserRepository userRepository;
 	private final PostAccessPolicy postAccessPolicy;
+
+	@Transactional
+	public LikePostResponse toggleLikePost(Long userId, Long postId) {
+		User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+			.orElseThrow(UserNotFoundException::new);
+
+		StudentCouncilPost post = studentCouncilPostRepository.findById(postId)
+			.orElseThrow(PostNotFoundException::new);
+
+		Optional<LikePost> likePost = likePostRepository.findByUserIdAndPost_Id(userId, postId);
+		boolean isLike;
+		if (likePost.isPresent()) {
+			likePostRepository.delete(likePost.get());
+			isLike = false;
+		} else {
+			LikePost newLikePost = studentCouncilPostMapper.createLikePost(user, post);
+			likePostRepository.save(newLikePost);
+			isLike = true;
+		}
+
+		return studentCouncilPostMapper.toLikePostResponse(user, post, isLike);
+	}
+
+	public Page<GetLikedPostResponse> findLikedPosts(PostCategory category, int page, int size, Long userId) {
+		userRepository.findByIdAndDeletedAtIsNull(userId)
+			.orElseThrow(UserNotFoundException::new);
+
+		Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size);
+
+		Page<LikePost> likedPosts = likePostRepository.findLikedPosts(userId, category, pageable);
+
+		return likedPosts.map(likePost ->
+			studentCouncilPostMapper.toGetLikedPostResponse(likePost.getPost())
+		);
+	}
 
 	public Page<PostListItemResponse> findSchoolPosts(PostCategory category, int page, int size, Long userId) {
 		User user = userRepository.findByIdWithAcademicInfo(userId).orElseThrow(UserNotFoundException::new);

--- a/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostService.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostService.java
@@ -3,7 +3,6 @@ package com.campus.campus.domain.councilpost.application.service;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -15,8 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 import com.campus.campus.domain.council.application.exception.StudentCouncilNotFoundException;
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.council.domain.repository.StudentCouncilRepository;
-import com.campus.campus.domain.councilpost.application.dto.response.GetLikedPostResponse;
-import com.campus.campus.domain.councilpost.application.dto.response.LikePostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.GetPostListForCouncilResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.GetUpcomingEventListForCouncilResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.NormalizedDateTime;
@@ -28,15 +25,12 @@ import com.campus.campus.domain.councilpost.application.exception.PostNotFoundEx
 import com.campus.campus.domain.councilpost.application.exception.PostOciImageDeleteFailedException;
 import com.campus.campus.domain.councilpost.application.exception.ThumbnailRequiredException;
 import com.campus.campus.domain.councilpost.application.mapper.StudentCouncilPostMapper;
-import com.campus.campus.domain.councilpost.domain.entity.LikePost;
 import com.campus.campus.domain.councilpost.domain.entity.PostCategory;
 import com.campus.campus.domain.councilpost.domain.entity.PostImage;
 import com.campus.campus.domain.councilpost.domain.entity.StudentCouncilPost;
 import com.campus.campus.domain.councilpost.domain.repository.LikePostRepository;
 import com.campus.campus.domain.councilpost.domain.repository.PostImageRepository;
 import com.campus.campus.domain.councilpost.domain.repository.StudentCouncilPostRepository;
-import com.campus.campus.domain.user.application.exception.UserNotFoundException;
-import com.campus.campus.domain.user.domain.entity.User;
 import com.campus.campus.domain.user.domain.repository.UserRepository;
 import com.campus.campus.global.oci.application.service.PresignedUrlService;
 
@@ -149,42 +143,6 @@ public class StudentCouncilPostService {
 			now, limit, pageable);
 
 		return posts.map(studentCouncilPostMapper::toGetUpcomingEventListForCouncilResponse);
-	}
-
-	@Transactional
-	public LikePostResponse toggleLikePost(Long userId, Long postId) {
-		User user = userRepository.findByIdAndDeletedAtIsNull(userId)
-			.orElseThrow(UserNotFoundException::new);
-
-		StudentCouncilPost post = postRepository.findById(postId)
-			.orElseThrow(PostNotFoundException::new);
-
-		Optional<LikePost> likePost = likePostRepository.findByUserIdAndPost_Id(userId, postId);
-		boolean isLike;
-		if (likePost.isPresent()) {
-			likePostRepository.delete(likePost.get());
-			isLike = false;
-		} else {
-			LikePost newLikePost = studentCouncilPostMapper.createLikePost(user, post);
-			likePostRepository.save(newLikePost);
-			isLike = true;
-		}
-
-		return studentCouncilPostMapper.toLikePostResponse(user, post, isLike);
-	}
-
-	@Transactional(readOnly = true)
-	public Page<GetLikedPostResponse> findLikedPosts(PostCategory category, int page, int size, Long userId) {
-		userRepository.findByIdAndDeletedAtIsNull(userId)
-			.orElseThrow(UserNotFoundException::new);
-
-		Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size);
-
-		Page<LikePost> likedPosts = likePostRepository.findLikedPosts(userId, category, pageable);
-
-		return likedPosts.map(likePost ->
-			studentCouncilPostMapper.toGetLikedPostResponse(likePost.getPost())
-		);
 	}
 
 	@Transactional

--- a/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostService.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostService.java
@@ -15,10 +15,10 @@ import com.campus.campus.domain.council.application.exception.StudentCouncilNotF
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.council.domain.repository.StudentCouncilRepository;
 import com.campus.campus.domain.councilpost.application.dto.response.GetPostListForCouncilResponse;
+import com.campus.campus.domain.councilpost.application.dto.response.GetPostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.GetUpcomingEventListForCouncilResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.NormalizedDateTime;
 import com.campus.campus.domain.councilpost.application.dto.request.PostRequest;
-import com.campus.campus.domain.councilpost.application.dto.response.PostResponse;
 import com.campus.campus.domain.councilpost.application.exception.NotPostWriterException;
 import com.campus.campus.domain.councilpost.application.exception.PostImageLimitExceededException;
 import com.campus.campus.domain.councilpost.application.exception.PostNotFoundException;
@@ -28,10 +28,8 @@ import com.campus.campus.domain.councilpost.application.mapper.StudentCouncilPos
 import com.campus.campus.domain.councilpost.domain.entity.PostCategory;
 import com.campus.campus.domain.councilpost.domain.entity.PostImage;
 import com.campus.campus.domain.councilpost.domain.entity.StudentCouncilPost;
-import com.campus.campus.domain.councilpost.domain.repository.LikePostRepository;
 import com.campus.campus.domain.councilpost.domain.repository.PostImageRepository;
 import com.campus.campus.domain.councilpost.domain.repository.StudentCouncilPostRepository;
-import com.campus.campus.domain.user.domain.repository.UserRepository;
 import com.campus.campus.global.oci.application.service.PresignedUrlService;
 
 import lombok.RequiredArgsConstructor;
@@ -45,8 +43,6 @@ public class StudentCouncilPostService {
 	private final StudentCouncilPostRepository postRepository;
 	private final StudentCouncilRepository studentCouncilRepository;
 	private final PostImageRepository postImageRepository;
-	private final LikePostRepository likePostRepository;
-	private final UserRepository userRepository;
 	private final PresignedUrlService presignedUrlService;
 	private final StudentCouncilPostMapper studentCouncilPostMapper;
 
@@ -54,7 +50,7 @@ public class StudentCouncilPostService {
 	private static final long UPCOMING_EVENT_WINDOW_HOURS = 72L;
 
 	@Transactional
-	public PostResponse create(Long councilId, PostRequest dto) {
+	public GetPostResponse create(Long councilId, PostRequest dto) {
 		if (dto.imageUrls() != null && dto.imageUrls().size() > MAX_IMAGE_COUNT) {
 			throw new PostImageLimitExceededException();
 		}
@@ -87,11 +83,11 @@ public class StudentCouncilPostService {
 			.map(PostImage::getImageUrl)
 			.toList();
 
-		return studentCouncilPostMapper.toPostResponse(post, imageUrls, councilId);
+		return studentCouncilPostMapper.toGetPostResponse(post, imageUrls, councilId);
 	}
 
 	@Transactional(readOnly = true)
-	public PostResponse findById(Long postId, Long currentUserId) {
+	public GetPostResponse findById(Long postId, Long currentUserId) {
 		StudentCouncilPost post = postRepository.findByIdWithFullInfo(postId)
 			.orElseThrow(PostNotFoundException::new);
 
@@ -101,7 +97,7 @@ public class StudentCouncilPostService {
 			.map(PostImage::getImageUrl)
 			.toList();
 
-		return studentCouncilPostMapper.toPostResponse(post, imageUrls, currentUserId);
+		return studentCouncilPostMapper.toGetPostResponse(post, imageUrls, currentUserId);
 	}
 
 	@Transactional(readOnly = true)
@@ -182,7 +178,7 @@ public class StudentCouncilPostService {
 	}
 
 	@Transactional
-	public PostResponse update(Long councilId, Long postId, PostRequest dto) {
+	public GetPostResponse update(Long councilId, Long postId, PostRequest dto) {
 		studentCouncilRepository.findByIdAndManagerApprovedIsTrueAndDeletedAtIsNull(councilId)
 			.orElseThrow(StudentCouncilNotFoundException::new);
 
@@ -234,7 +230,7 @@ public class StudentCouncilPostService {
 			.map(PostImage::getImageUrl)
 			.toList();
 
-		return studentCouncilPostMapper.toPostResponse(post, imageUrls, councilId);
+		return studentCouncilPostMapper.toGetPostResponse(post, imageUrls, councilId);
 	}
 
 	//이미지 삭제

--- a/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostService.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostService.java
@@ -3,6 +3,7 @@ package com.campus.campus.domain.councilpost.application.service;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.campus.campus.domain.council.application.exception.StudentCouncilNotFoundException;
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.council.domain.repository.StudentCouncilRepository;
+import com.campus.campus.domain.councilpost.application.dto.response.LikePostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.NormalizedDateTime;
 import com.campus.campus.domain.councilpost.application.dto.response.PostListItemResponse;
 import com.campus.campus.domain.councilpost.application.dto.request.PostRequest;
@@ -24,11 +26,16 @@ import com.campus.campus.domain.councilpost.application.exception.PostNotFoundEx
 import com.campus.campus.domain.councilpost.application.exception.PostOciImageDeleteFailedException;
 import com.campus.campus.domain.councilpost.application.exception.ThumbnailRequiredException;
 import com.campus.campus.domain.councilpost.application.mapper.StudentCouncilPostMapper;
+import com.campus.campus.domain.councilpost.domain.entity.LikePost;
 import com.campus.campus.domain.councilpost.domain.entity.PostCategory;
 import com.campus.campus.domain.councilpost.domain.entity.PostImage;
 import com.campus.campus.domain.councilpost.domain.entity.StudentCouncilPost;
+import com.campus.campus.domain.councilpost.domain.repository.LikePostRepository;
 import com.campus.campus.domain.councilpost.domain.repository.PostImageRepository;
 import com.campus.campus.domain.councilpost.domain.repository.StudentCouncilPostRepository;
+import com.campus.campus.domain.user.application.exception.UserNotFoundException;
+import com.campus.campus.domain.user.domain.entity.User;
+import com.campus.campus.domain.user.domain.repository.UserRepository;
 import com.campus.campus.global.oci.application.service.PresignedUrlService;
 
 import lombok.RequiredArgsConstructor;
@@ -42,6 +49,8 @@ public class StudentCouncilPostService {
 	private final StudentCouncilPostRepository postRepository;
 	private final StudentCouncilRepository studentCouncilRepository;
 	private final PostImageRepository postImageRepository;
+	private final LikePostRepository likePostRepository;
+	private final UserRepository userRepository;
 	private final PresignedUrlService presignedUrlService;
 	private final StudentCouncilPostMapper studentCouncilPostMapper;
 
@@ -128,6 +137,28 @@ public class StudentCouncilPostService {
 		return posts.map(post ->
 			studentCouncilPostMapper.toPostListItemResponse(post, currentUserId)
 		);
+	}
+
+	@Transactional
+	public LikePostResponse toggleLikePost(Long userId, Long postId) {
+		User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+			.orElseThrow(UserNotFoundException::new);
+
+		StudentCouncilPost post = postRepository.findById(postId)
+			.orElseThrow(PostNotFoundException::new);
+
+		Optional<LikePost> likePost = likePostRepository.findByUserIdAndPost_Id(userId, postId);
+		boolean isLike;
+		if (likePost.isPresent()) {
+			likePostRepository.delete(likePost.get());
+			isLike = false;
+		} else {
+			LikePost newLikePost = studentCouncilPostMapper.createLikePost(user, post);
+			likePostRepository.save(newLikePost);
+			isLike = true;
+		}
+
+		return studentCouncilPostMapper.toLikePostResponse(user, post, isLike);
 	}
 
 	@Transactional

--- a/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostService.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.campus.campus.domain.council.application.exception.StudentCouncilNotFoundException;
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.council.domain.repository.StudentCouncilRepository;
+import com.campus.campus.domain.councilpost.application.dto.response.GetLikedPostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.LikePostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.NormalizedDateTime;
 import com.campus.campus.domain.councilpost.application.dto.response.PostListItemResponse;
@@ -159,6 +160,20 @@ public class StudentCouncilPostService {
 		}
 
 		return studentCouncilPostMapper.toLikePostResponse(user, post, isLike);
+	}
+
+	@Transactional(readOnly = true)
+	public Page<GetLikedPostResponse> findLikedPosts(PostCategory category, int page, int size, Long userId) {
+		userRepository.findByIdAndDeletedAtIsNull(userId)
+			.orElseThrow(UserNotFoundException::new);
+
+		Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size);
+
+		Page<LikePost> likedPosts = likePostRepository.findLikedPosts(userId, category, pageable);
+
+		return likedPosts.map(likePost ->
+			studentCouncilPostMapper.toGetLikedPostResponse(likePost.getPost())
+		);
 	}
 
 	@Transactional

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/entity/LikePost.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/entity/LikePost.java
@@ -1,0 +1,40 @@
+package com.campus.campus.domain.councilpost.domain.entity;
+
+import static jakarta.persistence.FetchType.*;
+
+import com.campus.campus.domain.user.domain.entity.User;
+import com.campus.campus.global.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class LikePost extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "like_post_id")
+	private Long likePostId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "post_id")
+	private StudentCouncilPost post;
+}

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/entity/LikePost.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/entity/LikePost.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,6 +21,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(name = "like_posts")
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/entity/LikePost.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/entity/LikePost.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,7 +22,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "like_posts")
+@Table(name = "like_posts", uniqueConstraints =
+	{@UniqueConstraint(columnNames = {"user_id", "post_id"})})
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/entity/LikePost.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/entity/LikePost.java
@@ -22,8 +22,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "like_posts", uniqueConstraints =
-	{@UniqueConstraint(columnNames = {"user_id", "post_id"})})
+@Table(name = "like_posts", uniqueConstraints = {
+	@UniqueConstraint(columnNames = {"user_id", "post_id"})
+})
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/repository/LikePostRepository.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/repository/LikePostRepository.java
@@ -16,6 +16,8 @@ import com.campus.campus.domain.councilpost.domain.entity.PostCategory;
 public interface LikePostRepository extends JpaRepository<LikePost, Long> {
 	Optional<LikePost> findByUserIdAndPost_Id(Long userId, Long postId);
 
+	boolean existsByUserIdAndPost_Id(Long userId, Long postId);
+
 	@EntityGraph(attributePaths = {"post", "post.writer"})
 	@Query("""
 		SELECT lp FROM LikePost lp

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/repository/LikePostRepository.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/repository/LikePostRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -14,7 +15,12 @@ import com.campus.campus.domain.councilpost.domain.entity.LikePost;
 import com.campus.campus.domain.councilpost.domain.entity.PostCategory;
 
 public interface LikePostRepository extends JpaRepository<LikePost, Long> {
-	Optional<LikePost> findByUserIdAndPost_Id(Long userId, Long postId);
+	@Modifying(clearAutomatically = true)
+	@Query("""
+			DELETE FROM LikePost lp
+			WHERE lp.user.id = :userId AND lp.post.id = :postId
+		""")
+	int deleteByUserIdAndPostId(@Param("userId") Long userId, @Param("postId") Long postId);
 
 	boolean existsByUserIdAndPost_Id(Long userId, Long postId);
 

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/repository/LikePostRepository.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/repository/LikePostRepository.java
@@ -1,5 +1,6 @@
 package com.campus.campus.domain.councilpost.domain.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -25,4 +26,11 @@ public interface LikePostRepository extends JpaRepository<LikePost, Long> {
 		""")
 	Page<LikePost> findLikedPosts(@Param("userId") Long userId, @Param("category") PostCategory category,
 		Pageable pageable);
+
+	@Query("""
+		SELECT lp.post.id FROM LikePost lp
+		WHERE lp.user.id = :userId
+		  AND lp.post.id IN :postIds
+		""")
+	List<Long> findLikedPostIds(@Param("userId") Long userId, @Param("postIds") List<Long> postIds);
 }

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/repository/LikePostRepository.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/repository/LikePostRepository.java
@@ -1,0 +1,11 @@
+package com.campus.campus.domain.councilpost.domain.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.campus.campus.domain.councilpost.domain.entity.LikePost;
+
+public interface  LikePostRepository extends JpaRepository<LikePost, Long> {
+	Optional<LikePost> findByUserIdAndPost_Id(Long userId, Long postId);
+}

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/repository/LikePostRepository.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/repository/LikePostRepository.java
@@ -2,10 +2,27 @@ package com.campus.campus.domain.councilpost.domain.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.campus.campus.domain.councilpost.domain.entity.LikePost;
+import com.campus.campus.domain.councilpost.domain.entity.PostCategory;
 
-public interface  LikePostRepository extends JpaRepository<LikePost, Long> {
+public interface LikePostRepository extends JpaRepository<LikePost, Long> {
 	Optional<LikePost> findByUserIdAndPost_Id(Long userId, Long postId);
+
+	@EntityGraph(attributePaths = {"post", "post.writer"})
+	@Query("""
+		SELECT lp FROM LikePost lp
+		JOIN lp.post p
+		WHERE lp.user.id = :userId
+		  AND (:category IS NULL OR p.category = :category)
+		ORDER BY lp.createdAt DESC
+		""")
+	Page<LikePost> findLikedPosts(@Param("userId") Long userId, @Param("category") PostCategory category,
+		Pageable pageable);
 }

--- a/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostController.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostController.java
@@ -14,8 +14,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.campus.campus.domain.councilpost.application.dto.request.PostRequest;
 import com.campus.campus.domain.councilpost.application.dto.response.GetPostListForCouncilResponse;
+import com.campus.campus.domain.councilpost.application.dto.response.GetPostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.GetUpcomingEventListForCouncilResponse;
-import com.campus.campus.domain.councilpost.application.dto.response.PostResponse;
 import com.campus.campus.domain.councilpost.application.service.StudentCouncilPostService;
 import com.campus.campus.domain.councilpost.domain.entity.PostCategory;
 import com.campus.campus.global.annotation.CurrentCouncilId;
@@ -102,22 +102,22 @@ public class StudentCouncilPostController {
 			)
 		)
 	)
-	public CommonResponse<PostResponse> createPost(
+	public CommonResponse<GetPostResponse> createPost(
 		@CurrentCouncilId Long councilId,
 		@RequestBody @Valid PostRequest requestDto
 	) {
-		PostResponse responseDto = postService.create(councilId, requestDto);
+		GetPostResponse responseDto = postService.create(councilId, requestDto);
 		return CommonResponse.success(StudentCouncilPostResponseCode.POST_CREATE_SUCCESS, responseDto);
 	}
 
 	@PatchMapping("/{postId}")
 	@Operation(summary = "학생회 게시글 수정")
-	public CommonResponse<PostResponse> updatePost(
+	public CommonResponse<GetPostResponse> updatePost(
 		@CurrentCouncilId Long councilId,
 		@PathVariable Long postId,
 		@RequestBody @Valid PostRequest requestDto
 	) {
-		PostResponse responseDto = postService.update(councilId, postId, requestDto);
+		GetPostResponse responseDto = postService.update(councilId, postId, requestDto);
 
 		return CommonResponse.success(StudentCouncilPostResponseCode.POST_UPDATE_SUCCESS, responseDto);
 	}
@@ -132,8 +132,8 @@ public class StudentCouncilPostController {
 
 	@GetMapping("/{postId}")
 	@Operation(summary = "학생회 게시글 상세 조회")
-	public CommonResponse<PostResponse> getPost(@PathVariable Long postId, @CurrentCouncilId Long councilId) {
-		PostResponse responseDto = postService.findById(postId, councilId);
+	public CommonResponse<GetPostResponse> getPost(@PathVariable Long postId, @CurrentCouncilId Long councilId) {
+		GetPostResponse responseDto = postService.findById(postId, councilId);
 
 		return CommonResponse.success(StudentCouncilPostResponseCode.POST_READ_SUCCESS, responseDto);
 	}

--- a/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostController.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.campus.campus.domain.councilpost.application.dto.request.PostRequest;
+import com.campus.campus.domain.councilpost.application.dto.response.GetLikedPostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.LikePostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.PostListItemResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.PostResponse;
@@ -143,14 +144,6 @@ public class StudentCouncilPostController {
 		return CommonResponse.success(StudentCouncilPostResponseCode.POST_READ_SUCCESS, responseDto);
 	}
 
-	@PostMapping("/{postId}/like")
-	@Operation(summary = "학생회 게시글 좋아요 토글")
-	public CommonResponse<LikePostResponse> togglePostLike(@PathVariable Long postId, @CurrentUserId Long userId) {
-		LikePostResponse response = postService.toggleLikePost(userId, postId);
-
-		return CommonResponse.success(StudentCouncilPostResponseCode.POST_LIKE_SUCCESS, response);
-	}
-
 	@GetMapping
 	@Operation(
 		summary = "학생회 게시글 목록 조회 (필터링 포함)",
@@ -182,5 +175,28 @@ public class StudentCouncilPostController {
 		return CommonResponse.success(StudentCouncilPostResponseCode.POST_LIST_READ_SUCCESS,
 			postService.findUpcomingEvents(page, size, councilId)
 		);
+	}
+
+	@PostMapping("/{postId}/like")
+	@PreAuthorize("hasRole('USER')")
+	@Operation(summary = "학생회 게시글 좋아요 토글")
+	public CommonResponse<LikePostResponse> togglePostLike(@PathVariable Long postId, @CurrentUserId Long userId) {
+		LikePostResponse response = postService.toggleLikePost(userId, postId);
+
+		return CommonResponse.success(StudentCouncilPostResponseCode.POST_LIKE_SUCCESS, response);
+	}
+
+	@GetMapping("/likes")
+	@PreAuthorize("hasRole('USER')")
+	@Operation(summary = "관심 학생회 게시글 목록 조회")
+	public CommonResponse<Page<GetLikedPostResponse>> getLikedPosts(
+		@RequestParam(required = false) PostCategory category,
+		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "3") int size,
+		@CurrentUserId Long userId
+	) {
+		Page<GetLikedPostResponse> responses = postService.findLikedPosts(category, page, size, userId);
+
+		return CommonResponse.success(StudentCouncilPostResponseCode.POST_LIST_READ_SUCCESS, responses);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostController.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostController.java
@@ -13,11 +13,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.campus.campus.domain.councilpost.application.dto.request.PostRequest;
+import com.campus.campus.domain.councilpost.application.dto.response.LikePostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.PostListItemResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.PostResponse;
 import com.campus.campus.domain.councilpost.application.service.StudentCouncilPostService;
 import com.campus.campus.domain.councilpost.domain.entity.PostCategory;
 import com.campus.campus.global.annotation.CurrentCouncilId;
+import com.campus.campus.global.annotation.CurrentUserId;
 import com.campus.campus.global.common.response.CommonResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -139,6 +141,14 @@ public class StudentCouncilPostController {
 			postService.findById(postId, councilId);
 
 		return CommonResponse.success(StudentCouncilPostResponseCode.POST_READ_SUCCESS, responseDto);
+	}
+
+	@PostMapping("/{postId}/like")
+	@Operation(summary = "학생회 게시글 좋아요 토글")
+	public CommonResponse<LikePostResponse> togglePostLike(@PathVariable Long postId, @CurrentUserId Long userId) {
+		LikePostResponse response = postService.toggleLikePost(userId, postId);
+
+		return CommonResponse.success(StudentCouncilPostResponseCode.POST_LIKE_SUCCESS, response);
 	}
 
 	@GetMapping

--- a/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostController.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostController.java
@@ -13,15 +13,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.campus.campus.domain.councilpost.application.dto.request.PostRequest;
-import com.campus.campus.domain.councilpost.application.dto.response.GetLikedPostResponse;
-import com.campus.campus.domain.councilpost.application.dto.response.LikePostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.GetPostListForCouncilResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.GetUpcomingEventListForCouncilResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.PostResponse;
 import com.campus.campus.domain.councilpost.application.service.StudentCouncilPostService;
 import com.campus.campus.domain.councilpost.domain.entity.PostCategory;
 import com.campus.campus.global.annotation.CurrentCouncilId;
-import com.campus.campus.global.annotation.CurrentUserId;
 import com.campus.campus.global.common.response.CommonResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -166,28 +163,5 @@ public class StudentCouncilPostController {
 			page, size);
 
 		return CommonResponse.success(StudentCouncilPostResponseCode.POST_LIST_READ_SUCCESS, response);
-	}
-
-	@PostMapping("/{postId}/like")
-	@PreAuthorize("hasRole('USER')")
-	@Operation(summary = "학생회 게시글 좋아요 토글")
-	public CommonResponse<LikePostResponse> togglePostLike(@PathVariable Long postId, @CurrentUserId Long userId) {
-		LikePostResponse response = postService.toggleLikePost(userId, postId);
-
-		return CommonResponse.success(StudentCouncilPostResponseCode.POST_LIKE_SUCCESS, response);
-	}
-
-	@GetMapping("/likes")
-	@PreAuthorize("hasRole('USER')")
-	@Operation(summary = "관심 학생회 게시글 목록 조회")
-	public CommonResponse<Page<GetLikedPostResponse>> getLikedPosts(
-		@RequestParam(required = false) PostCategory category,
-		@RequestParam(defaultValue = "1") int page,
-		@RequestParam(defaultValue = "3") int size,
-		@CurrentUserId Long userId
-	) {
-		Page<GetLikedPostResponse> responses = postService.findLikedPosts(category, page, size, userId);
-
-		return CommonResponse.success(StudentCouncilPostResponseCode.POST_LIST_READ_SUCCESS, responses);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostForUserController.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostForUserController.java
@@ -6,12 +6,15 @@ import org.springframework.data.domain.Page;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.campus.campus.domain.council.domain.entity.CouncilType;
 import com.campus.campus.domain.councilpost.application.dto.response.GetActivePartnershipListForUserResponse;
+import com.campus.campus.domain.councilpost.application.dto.response.GetLikedPostResponse;
+import com.campus.campus.domain.councilpost.application.dto.response.LikePostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.PostListItemResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.PostResponse;
 import com.campus.campus.domain.councilpost.application.service.StudentCouncilPostForUserService;
@@ -31,6 +34,29 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class StudentCouncilPostForUserController {
+
+	@PostMapping("/{postId}/like")
+	@PreAuthorize("hasRole('USER')")
+	@Operation(summary = "학생회 게시글 좋아요 토글")
+	public CommonResponse<LikePostResponse> togglePostLike(@PathVariable Long postId, @CurrentUserId Long userId) {
+		LikePostResponse response = postService.toggleLikePost(userId, postId);
+
+		return CommonResponse.success(StudentCouncilPostResponseCode.POST_LIKE_SUCCESS, response);
+	}
+
+	@GetMapping("/likes")
+	@PreAuthorize("hasRole('USER')")
+	@Operation(summary = "관심 학생회 게시글 목록 조회")
+	public CommonResponse<Page<GetLikedPostResponse>> getLikedPosts(
+		@RequestParam(required = false) PostCategory category,
+		@RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "3") int size,
+		@CurrentUserId Long userId
+	) {
+		Page<GetLikedPostResponse> responses = postService.findLikedPosts(category, page, size, userId);
+
+		return CommonResponse.success(StudentCouncilPostResponseCode.POST_LIST_READ_SUCCESS, responses);
+	}
 
 	private final StudentCouncilPostForUserService postService;
 

--- a/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostForUserController.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostForUserController.java
@@ -36,7 +36,6 @@ import lombok.extern.slf4j.Slf4j;
 public class StudentCouncilPostForUserController {
 
 	@PostMapping("/{postId}/like")
-	@PreAuthorize("hasRole('USER')")
 	@Operation(summary = "학생회 게시글 좋아요 토글")
 	public CommonResponse<LikePostResponse> togglePostLike(@PathVariable Long postId, @CurrentUserId Long userId) {
 		LikePostResponse response = postService.toggleLikePost(userId, postId);
@@ -45,7 +44,6 @@ public class StudentCouncilPostForUserController {
 	}
 
 	@GetMapping("/likes")
-	@PreAuthorize("hasRole('USER')")
 	@Operation(summary = "관심 학생회 게시글 목록 조회")
 	public CommonResponse<Page<GetLikedPostResponse>> getLikedPosts(
 		@RequestParam(required = false) PostCategory category,

--- a/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostForUserController.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostForUserController.java
@@ -16,7 +16,7 @@ import com.campus.campus.domain.councilpost.application.dto.response.GetActivePa
 import com.campus.campus.domain.councilpost.application.dto.response.GetLikedPostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.LikePostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.PostListItemResponse;
-import com.campus.campus.domain.councilpost.application.dto.response.PostResponse;
+import com.campus.campus.domain.councilpost.application.dto.response.GetPostResponseForUser;
 import com.campus.campus.domain.councilpost.application.service.StudentCouncilPostForUserService;
 import com.campus.campus.domain.councilpost.domain.entity.PostCategory;
 import com.campus.campus.global.annotation.CurrentUserId;
@@ -110,11 +110,11 @@ public class StudentCouncilPostForUserController {
 
 	@GetMapping("/{postId}")
 	@Operation(summary = "학생회 게시글 상세 조회")
-	public CommonResponse<PostResponse> getPost(
+	public CommonResponse<GetPostResponseForUser> getPost(
 		@PathVariable Long postId,
 		@CurrentUserId Long userId
 	) {
-		PostResponse responseDto = postService.findById(postId, userId);
+		GetPostResponseForUser responseDto = postService.findById(postId, userId);
 
 		return CommonResponse.success(StudentCouncilPostResponseCode.POST_READ_SUCCESS, responseDto);
 	}

--- a/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostForUserController.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostForUserController.java
@@ -16,7 +16,7 @@ import com.campus.campus.domain.councilpost.application.dto.response.GetActivePa
 import com.campus.campus.domain.councilpost.application.dto.response.GetLikedPostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.LikePostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.PostListItemResponse;
-import com.campus.campus.domain.councilpost.application.dto.response.GetPostResponseForUser;
+import com.campus.campus.domain.councilpost.application.dto.response.GetPostForUserResponse;
 import com.campus.campus.domain.councilpost.application.service.StudentCouncilPostForUserService;
 import com.campus.campus.domain.councilpost.domain.entity.PostCategory;
 import com.campus.campus.global.annotation.CurrentUserId;
@@ -110,11 +110,11 @@ public class StudentCouncilPostForUserController {
 
 	@GetMapping("/{postId}")
 	@Operation(summary = "학생회 게시글 상세 조회")
-	public CommonResponse<GetPostResponseForUser> getPost(
+	public CommonResponse<GetPostForUserResponse> getPost(
 		@PathVariable Long postId,
 		@CurrentUserId Long userId
 	) {
-		GetPostResponseForUser responseDto = postService.findById(postId, userId);
+		GetPostForUserResponse responseDto = postService.findById(postId, userId);
 
 		return CommonResponse.success(StudentCouncilPostResponseCode.POST_READ_SUCCESS, responseDto);
 	}

--- a/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostResponseCode.java
@@ -15,7 +15,8 @@ public enum StudentCouncilPostResponseCode implements ResponseCodeInterface {
 	POST_READ_SUCCESS(200, HttpStatus.OK, "게시글 조회에 성공했습니다."),
 	POST_LIST_READ_SUCCESS(200, HttpStatus.OK, "게시글 목록 조회에 성공했습니다."),
 	POST_UPDATE_SUCCESS(200, HttpStatus.OK, "게시글 수정에 성공했습니다."),
-	POST_DELETE_SUCCESS(200, HttpStatus.OK, "게시글 삭제에 성공했습니다.");
+	POST_DELETE_SUCCESS(200, HttpStatus.OK, "게시글 삭제에 성공했습니다."),
+	POST_LIKE_SUCCESS(200, HttpStatus.OK, "게시글 좋아요 처리에 성공했습니다.");
 
 	private final int code;
 	private final HttpStatus status;


### PR DESCRIPTION
## 🔀 변경 내용
- 학생회가 올린 게시글(제휴, 행사)에 좋아요를 눌러 관심 게시글로 등록하고 조회하는 기능을 구현했습니다.

## ✅ 작업 항목
- [x] 게시글 좋아요 등록 구현
- [x] 관심 게시글 조회(제휴, 행사 별 필터링) 기능 구현 (좋아요 누른 순서 내림차순)

## 📸 스크린샷 (선택)

### 좋아요 등록
- 하나의 API를 토글 형식으로 구현해 좋아요와 좋아요 취소가 같이 동작하게 구현했습니다.
<img width="1457" height="736" alt="image" src="https://github.com/user-attachments/assets/bc06a2eb-8251-4b8b-ae21-08205a31cb06" />
<img width="1457" height="736" alt="image" src="https://github.com/user-attachments/assets/17107312-01d1-4528-98b0-49840f4c1a3b" />

### 관심 게시물 목록 조회
<img width="1447" height="581" alt="image" src="https://github.com/user-attachments/assets/a3ba73e9-11c5-4d03-b898-400117bcf2b1" />


## 📎 참고 이슈
관련 이슈 번호 #42 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게시글 좋아요 기능 추가 - 사용자가 게시글을 좋아요 표시하고 해제할 수 있음
  * 좋아요한 게시글 목록 조회 기능 추가 - 카테고리 필터 및 페이지네이션 지원
  * 게시글 응답에 좋아요 상태 표시 추가 - 사용자가 게시글의 좋아요 여부를 확인 가능

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->