### PR TITLE
Refactor/#57 행사 게시글 생성 시 장소 상세정보 입력하도록 수정

### DIFF
--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/request/PostRequest.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/request/PostRequest.java
@@ -45,6 +45,9 @@ public record PostRequest(
 	@Valid
 	SavedPlaceInfo place,
 
+	@Schema(description = "상세 장소 (예: 310관 B301호)", example = "310관 B301호") // 추가됨
+	String detailedLocation,
+
 	@Schema(example = "2025-04-10T18:00")
 	@JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
 	LocalDateTime startDateTime,

--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetLikedPostResponse.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetLikedPostResponse.java
@@ -2,8 +2,11 @@ package com.campus.campus.domain.councilpost.application.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record GetLikedPostResponse(
 	@Schema(description = "게시글 id", example = "1")
 	Long postId,
@@ -13,6 +16,9 @@ public record GetLikedPostResponse(
 
 	@Schema(description = "게시글 장소", example = "투썸 플레이스")
 	String place,
+
+	@Schema(description = "상세 장소", example = "가천관 301호")
+	String detailedLocation,
 
 	@Schema(description = "시간(끝나는 시간 or 행사날짜)", example = "2026-01-10T18:00:00")
 	LocalDateTime dateTime,

--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetPostForUserResponse.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetPostForUserResponse.java
@@ -22,6 +22,7 @@ public record GetPostForUserResponse(
 	String title,
 	String content,
 	String place,
+	String detailedLocation,
 	LocalDate startDate,
 	LocalDate endDate,
 	LocalDateTime startDateTime,

--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetPostListForCouncilResponse.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetPostListForCouncilResponse.java
@@ -4,9 +4,11 @@ import java.time.LocalDateTime;
 
 import com.campus.campus.domain.councilpost.domain.entity.PostCategory;
 import com.campus.campus.domain.councilpost.domain.entity.ThumbnailIcon;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record GetPostListForCouncilResponse(
 	@Schema(description = "게시글 id", example = "1")
 	Long postId,
@@ -19,6 +21,9 @@ public record GetPostListForCouncilResponse(
 
 	@Schema(description = "장소", example = "310관 1층")
 	String place,
+
+	@Schema(description = "상세 장소", example = "가천관 301호")
+	String detailedLocation,
 
 	@Schema(description = "시간(끝나는 시간 or 행사날짜", example = "2026-01-10T18:00:00")
 	LocalDateTime dateTime,

--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetPostResponse.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetPostResponse.java
@@ -23,6 +23,7 @@ public record GetPostResponse(
 	String title,
 	String content,
 	String placeName,
+	String detailedLocation,
 	LocalDate startDate,
 	LocalDate endDate,
 	LocalDateTime startDateTime,

--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetUpcomingEventListForCouncilResponse.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetUpcomingEventListForCouncilResponse.java
@@ -20,6 +20,9 @@ public record GetUpcomingEventListForCouncilResponse(
 	@Schema(description = "장소", example = "310관 1층")
 	String place,
 
+	@Schema(description = "상세 장소", example = "가천관 301호")
+	String detailedLocation,
+
 	@Schema(description = "시간(끝나는 시간 or 행사날짜", example = "2026-01-10T18:00:00")
 	LocalDateTime dateTime,
 

--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/PostListItemResponse.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/PostListItemResponse.java
@@ -4,12 +4,15 @@ import java.time.LocalDateTime;
 
 import com.campus.campus.domain.councilpost.domain.entity.PostCategory;
 import com.campus.campus.domain.councilpost.domain.entity.ThumbnailIcon;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record PostListItemResponse(
 	Long id,
 	PostCategory category,
 	String title,
 	String placeName,
+	String detailedLocation,
 	LocalDateTime endDateTime,
 	String thumbnailImageUrl,
 	ThumbnailIcon thumbnailIcon,

--- a/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
@@ -141,6 +141,7 @@ public class StudentCouncilPostMapper {
 			post.getId(),
 			post.getTitle(),
 			post.getPlace().getPlaceName(),
+			post.getDetailedLocation(),
 			post.isEvent() ? post.getStartDateTime() : post.getEndDateTime(),
 			post.getThumbnailImageUrl()
 		);

--- a/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
@@ -86,6 +86,7 @@ public class StudentCouncilPostMapper {
 			.title(post.getTitle())
 			.content(post.getContent())
 			.placeName(post.getPlace().getPlaceName())
+			.detailedLocation(post.getDetailedLocation())
 			.thumbnailImageUrl(post.getThumbnailImageUrl())
 			.thumbnailIcon(post.getThumbnailIcon())
 			.images(images != null ? images : Collections.emptyList());
@@ -111,6 +112,7 @@ public class StudentCouncilPostMapper {
 			.title(post.getTitle())
 			.content(post.getContent())
 			.place(post.getPlace().getPlaceName())
+			.detailedLocation(post.getDetailedLocation())
 			.thumbnailImageUrl(post.getThumbnailImageUrl())
 			.thumbnailIcon(post.getThumbnailIcon())
 			.isLiked(isLiked)
@@ -152,6 +154,7 @@ public class StudentCouncilPostMapper {
 			.title(dto.title())
 			.content(dto.content())
 			.place(place)
+			.detailedLocation(dto.detailedLocation())
 			.startDateTime(startDateTime)
 			.endDateTime(endDateTime)
 			.thumbnailImageUrl(dto.thumbnailImageUrl())

--- a/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
@@ -62,6 +62,7 @@ public class StudentCouncilPostMapper {
 			post.getCategory(),
 			post.getTitle(),
 			post.getPlace().getPlaceName(),
+			post.getDetailedLocation(),
 			post.getStartDateTime(),
 			post.getThumbnailIcon()
 		);

--- a/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
@@ -49,6 +49,7 @@ public class StudentCouncilPostMapper {
 			post.getCategory(),
 			post.getTitle(),
 			post.getPlace().getPlaceName(),
+			post.getDetailedLocation(),
 			post.isEvent() ? post.getStartDateTime() : post.getEndDateTime(),
 			post.getThumbnailImageUrl(),
 			post.getThumbnailIcon()

--- a/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
@@ -34,9 +34,8 @@ public class StudentCouncilPostMapper {
 			post.getCategory(),
 			post.getTitle(),
 			post.getPlace().getPlaceName(),
-			post.isEvent()
-				? post.getStartDateTime()
-				: post.getEndDateTime(),
+			post.getDetailedLocation(),
+			post.isEvent() ? post.getStartDateTime() : post.getEndDateTime(),
 			post.getThumbnailImageUrl(),
 			post.getThumbnailIcon(),
 			isLiked

--- a/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostService.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostService.java
@@ -221,6 +221,7 @@ public class StudentCouncilPostService {
 			dto.title(),
 			dto.content(),
 			place,
+			dto.detailedLocation(),
 			normalized.startDateTime(),
 			normalized.endDateTime(),
 			dto.thumbnailImageUrl(),

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/entity/StudentCouncilPost.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/entity/StudentCouncilPost.java
@@ -50,6 +50,9 @@ public class StudentCouncilPost extends BaseEntity {
 	@JoinColumn(name = "place_id")
 	private Place place;
 
+	@Column(name = "detailed_location")
+	private String detailedLocation;
+
 	private LocalDateTime startDateTime;
 	private LocalDateTime endDateTime;
 
@@ -62,6 +65,7 @@ public class StudentCouncilPost extends BaseEntity {
 		String title,
 		String content,
 		Place place,
+		String detailedLocation,
 		LocalDateTime startDateTime,
 		LocalDateTime endDateTime,
 		String thumbnailImageUrl,
@@ -71,6 +75,7 @@ public class StudentCouncilPost extends BaseEntity {
 		this.title = title;
 		this.content = content;
 		this.place = place;
+		this.detailedLocation = detailedLocation;
 		this.startDateTime = startDateTime;
 		this.endDateTime = endDateTime;
 		this.category = category;

--- a/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostController.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostController.java
@@ -92,6 +92,7 @@ public class StudentCouncilPostController {
 							      "https://maps.googleapis.com/maps/api/place/photo?maxWidth=800&photo_reference=example3"
 							    ]
 							  },
+							  "detailedLocation": "대운동장",
 							  "startDateTime": "2025-04-10T18:00",
 							  "thumbnailIcon": "EVENT",
 							  "imageUrls": []


### PR DESCRIPTION
## 🔀 변경 내용
- 행사 게시글 생성 시 장소 상세정보 입력하며 행사 게시글 조회하는 API들에 장소의 상세정보도 조회되도록 수정했습니다.

## ✅ 작업 항목
- [x] StudentCouncilPost 테이블에 detailedLocation 필드를 추가해 행사 게시글 생성 및 수정 시 detailedLocation도 포함하도록 했습니다.(행사 게시글 한정)
- [x] 행사 게시글 조회가 포함된 API들에 detailedLocation도 응답 DTO에 포함되도록 수정했습니다. (제휴 게시글에서는 null로 되어있는 detailedLoaction이 조회되지 않게 하기 위해 @JsonInclude(JsonInclude.Include.NON_NULL)를 추가했습니다.

## 📸 스크린샷 (선택)
### 행사 게시글 생성
<img width="1455" height="490" alt="image" src="https://github.com/user-attachments/assets/0e58a1b8-b1f6-4140-bc11-d416592325e1" />

### 학생회 행사 목록 조회(학생회 홈화면)
<img width="1465" height="576" alt="image" src="https://github.com/user-attachments/assets/db080227-ad39-4032-8719-dcf93a0e1eb7" />

### 학생회 게시글 상세 조회(학생회용)
<img width="1467" height="489" alt="image" src="https://github.com/user-attachments/assets/29cc07ea-1781-4fdd-a9de-597dd50022ed" />

### 학생회 72시간 이내 행사 조회
<img width="1456" height="405" alt="image" src="https://github.com/user-attachments/assets/5c907800-258b-4aab-94d3-bbe28d500cf8" />

### 학생회 게시글 상세 조회(유저용)
<img width="1490" height="494" alt="image" src="https://github.com/user-attachments/assets/db605bc3-292a-4be6-aab4-2b78f784068b" />

### 학생회 게시글 목록 조회(유저용)
<img width="1475" height="596" alt="image" src="https://github.com/user-attachments/assets/f58bba90-6bba-4d5a-a879-35f54ed49094" />

### 학생회 72시간 이내 행사 조회(유저용)
<img width="1461" height="575" alt="image" src="https://github.com/user-attachments/assets/75ab0b65-40b3-4cd6-aaee-30c6fd07585e" />


## 📎 참고 이슈
관련 이슈 번호 #57 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 게시물 생성 및 수정 시 상세 위치 정보 입력 기능 추가
  * 게시물 조회 응답에 상세 위치 정보 포함
  * JSON 응답에서 null 값 자동 제외 처리로 응답 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->