### PR TITLE
Feat/#61 시간대별 랜덤 장소 추천 기능(홈화면) 구현

### DIFF
--- a/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
@@ -107,18 +107,21 @@ public class StudentCouncilPostForUserService {
 		return studentCouncilPostMapper.toGetPostForUserResponse(post, imageUrls, userId, isLiked);
 	}
 
-	public Page<PostListItemResponse> findSchoolPosts(PostCategory category, int page, int size, Long userId, Long excludePostId) {
+	public Page<PostListItemResponse> findSchoolPosts(PostCategory category, int page, int size, Long userId,
+		Long excludePostId) {
 		User user = userRepository.findByIdWithAcademicInfo(userId).orElseThrow(UserNotFoundException::new);
 
 		Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size, Sort.by(Sort.Direction.DESC, "startDateTime"));
 
 		Page<StudentCouncilPost> posts = studentCouncilPostRepository
-			.findBySchoolId(user.getSchool().getSchoolId(), category, CouncilType.SCHOOL_COUNCIL, excludePostId, pageable);
+			.findBySchoolId(user.getSchool().getSchoolId(), category, CouncilType.SCHOOL_COUNCIL, excludePostId,
+				pageable);
 
 		return mapPostsWithLikes(posts, userId);
 	}
 
-	public Page<PostListItemResponse> findCollegePosts(PostCategory category, int page, int size, Long userId, Long excludePostId) {
+	public Page<PostListItemResponse> findCollegePosts(PostCategory category, int page, int size, Long userId,
+		Long excludePostId) {
 		User user = userRepository.findByIdWithAcademicInfo(userId).orElseThrow(UserNotFoundException::new);
 
 		if (user.isProfileNotCompleted() || user.getCollege() == null) {
@@ -128,12 +131,14 @@ public class StudentCouncilPostForUserService {
 		Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size, Sort.by(Sort.Direction.DESC, "startDateTime"));
 
 		Page<StudentCouncilPost> posts = studentCouncilPostRepository
-			.findByCollegeId(user.getCollege().getCollegeId(), category, CouncilType.COLLEGE_COUNCIL, excludePostId, pageable);
+			.findByCollegeId(user.getCollege().getCollegeId(), category, CouncilType.COLLEGE_COUNCIL, excludePostId,
+				pageable);
 
 		return mapPostsWithLikes(posts, userId);
 	}
 
-	public Page<PostListItemResponse> findMajorPosts(PostCategory category, int page, int size, Long userId, Long excludePostId) {
+	public Page<PostListItemResponse> findMajorPosts(PostCategory category, int page, int size, Long userId,
+		Long excludePostId) {
 		User user = userRepository.findByIdWithAcademicInfo(userId).orElseThrow(UserNotFoundException::new);
 
 		if (user.isProfileNotCompleted() || user.getMajor() == null) {

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/repository/StudentCouncilPostRepository.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/repository/StudentCouncilPostRepository.java
@@ -300,7 +300,7 @@ public interface StudentCouncilPostRepository extends JpaRepository<StudentCounc
             OR (w.councilType = 'COLLEGE_COUNCIL' AND c.collegeId = :collegeId)
             OR (w.councilType = 'MAJOR_COUNCIL' AND m.majorId = :majorId)
           )
-        ORDER BY function('RAND')
+        ORDER BY p.id DESC
         """)
 	List<StudentCouncilPost> findRandomPartnershipPlace(
 		@Param("schoolId") Long schoolId,

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/repository/StudentCouncilPostRepository.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/repository/StudentCouncilPostRepository.java
@@ -14,6 +14,7 @@ import org.springframework.data.repository.query.Param;
 import com.campus.campus.domain.council.domain.entity.CouncilType;
 import com.campus.campus.domain.councilpost.domain.entity.PostCategory;
 import com.campus.campus.domain.councilpost.domain.entity.StudentCouncilPost;
+import com.campus.campus.domain.councilpost.domain.entity.ThumbnailIcon;
 
 public interface StudentCouncilPostRepository extends JpaRepository<StudentCouncilPost, Long> {
 
@@ -280,5 +281,33 @@ public interface StudentCouncilPostRepository extends JpaRepository<StudentCounc
 		@Param("minLng") Double minLng,
 		@Param("maxLng") Double maxLng,
 		@Param("now") LocalDateTime now
+	);
+
+	@EntityGraph(attributePaths = {"writer", "writer.school", "writer.college", "writer.major", "place"})
+	@Query("""
+        SELECT p FROM StudentCouncilPost p
+        JOIN FETCH p.writer w
+        JOIN FETCH p.place pl
+        LEFT JOIN w.school s
+        LEFT JOIN w.college c
+        LEFT JOIN w.major m
+        WHERE p.category = 'PARTNERSHIP'
+          AND p.thumbnailIcon = :icon
+          AND :now BETWEEN p.startDateTime AND p.endDateTime
+          AND w.deletedAt IS NULL
+          AND (
+               (w.councilType = 'SCHOOL_COUNCIL' AND s.schoolId = :schoolId)
+            OR (w.councilType = 'COLLEGE_COUNCIL' AND c.collegeId = :collegeId)
+            OR (w.councilType = 'MAJOR_COUNCIL' AND m.majorId = :majorId)
+          )
+        ORDER BY function('RAND')
+        """)
+	List<StudentCouncilPost> findRandomPartnershipPlace(
+		@Param("schoolId") Long schoolId,
+		@Param("collegeId") Long collegeId,
+		@Param("majorId") Long majorId,
+		@Param("icon") ThumbnailIcon icon,
+		@Param("now") LocalDateTime now,
+		Pageable pageable
 	);
 }

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/repository/StudentCouncilPostRepository.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/repository/StudentCouncilPostRepository.java
@@ -286,8 +286,8 @@ public interface StudentCouncilPostRepository extends JpaRepository<StudentCounc
 	@EntityGraph(attributePaths = {"writer", "writer.school", "writer.college", "writer.major", "place"})
 	@Query("""
         SELECT p FROM StudentCouncilPost p
-        JOIN FETCH p.writer w
-        JOIN FETCH p.place pl
+        JOIN p.writer w
+        JOIN p.place pl
         LEFT JOIN w.school s
         LEFT JOIN w.college c
         LEFT JOIN w.major m

--- a/src/main/java/com/campus/campus/domain/place/application/dto/response/RecommendNearByPlaceResponse.java
+++ b/src/main/java/com/campus/campus/domain/place/application/dto/response/RecommendNearByPlaceResponse.java
@@ -1,0 +1,39 @@
+package com.campus.campus.domain.place.application.dto.response;
+
+import java.util.List;
+
+import com.campus.campus.domain.place.domain.entity.Coordinate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record RecommendNearByPlaceResponse(
+	@Schema(description = "해당 장소명", example = "숙명여자대학교")
+	@NotBlank
+	String placeName,
+
+	@Schema(description = "장소 식별 고유 ID")
+	@NotBlank
+	String placeKey,
+
+	@Schema(description = "장소 주소", example = "서울특별시 용산구 청파로47길 99")
+	@NotBlank
+	String address,
+
+	@Schema(description = "장소 카테고리", example = "교육,학문>대학교")
+	@NotBlank
+	String category,
+
+	@Schema(description = "장소 상세 정보 네이버 페이지 하이퍼링크", example = "https://map.naver.com/v5/search/%EC%88%99%EB%AA%85%EC%97%AC%EC%9E%90%EB%8C%80%ED%95%99%EA%B5%90+%EC%A0%9C1%EC%BA%A0%ED%8D%BC%EC%8A%A4?c=37.545947,126.964578,15,0,0,0,dh")
+	String link,
+
+	@Schema(description = "전화번호", example = "010-1234-1234")
+	String telephone,
+
+	@Schema(description = "위도/경도")
+	Coordinate coordinate,
+
+	@Schema(description = "이미지 url")
+	List<String> imgUrls
+) {
+}

--- a/src/main/java/com/campus/campus/domain/place/application/dto/response/RecommendPartnershipPlaceResponse.java
+++ b/src/main/java/com/campus/campus/domain/place/application/dto/response/RecommendPartnershipPlaceResponse.java
@@ -1,0 +1,24 @@
+package com.campus.campus.domain.place.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record RecommendPartnershipPlaceResponse(
+	@Schema(description = "장소 ID", example = "10")
+	Long placeId,
+
+	@Schema(description = "장소 이름", example = "봉구스밥버거 중앙대후문점")
+	String placeName,
+
+	@Schema(description = "제휴한 학생회 이름", example = "가천대학교 총학생회")
+	String councilName,
+
+	@Schema(description = "제휴 이름 (게시글 제목)", example = "전 메뉴 10% 할인")
+	String partnershipTitle,
+
+	@Schema(description = "장소 주소", example = "서울특별시 동작구 상도1동")
+	String address,
+
+	@Schema(description = "제휴 썸네일 이미지", example = "https://cdn.example.com/image.jpg")
+	String imageUrl
+) {
+}

--- a/src/main/java/com/campus/campus/domain/place/application/dto/response/RecommendPlaceByTimeResponse.java
+++ b/src/main/java/com/campus/campus/domain/place/application/dto/response/RecommendPlaceByTimeResponse.java
@@ -1,0 +1,17 @@
+package com.campus.campus.domain.place.application.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record RecommendPlaceByTimeResponse(
+	@Schema(description = "추천 타입 (LUNCH: 점심, CAFE: 카페, NONE: 해당 시간 아님)", example = "LUNCH")
+	String type,
+
+	@Schema(description = "추천 제휴 게시글 (최대 2개)")
+	List<RecommendPartnershipPlaceResponse> partnershipPosts,
+
+	@Schema(description = "추천 주변 장소 (최대 2개)")
+	List<RecommendNearByPlaceResponse> nearbyPlaces
+) {
+}

--- a/src/main/java/com/campus/campus/domain/place/application/mapper/PlaceMapper.java
+++ b/src/main/java/com/campus/campus/domain/place/application/mapper/PlaceMapper.java
@@ -8,6 +8,9 @@ import com.campus.campus.domain.council.domain.entity.CouncilType;
 import com.campus.campus.domain.councilpost.domain.entity.StudentCouncilPost;
 import com.campus.campus.domain.place.application.dto.response.PartnershipPinResponse;
 import com.campus.campus.domain.place.application.dto.response.LikeResponse;
+import com.campus.campus.domain.place.application.dto.response.RecommendNearByPlaceResponse;
+import com.campus.campus.domain.place.application.dto.response.RecommendPartnershipPlaceResponse;
+import com.campus.campus.domain.place.application.dto.response.RecommendPlaceByTimeResponse;
 import com.campus.campus.domain.place.application.dto.response.SavedPlaceInfo;
 import com.campus.campus.domain.place.application.dto.response.naver.NaverSearchResponse;
 import com.campus.campus.domain.place.application.dto.response.partnership.PartnershipResponse;
@@ -66,6 +69,37 @@ public class PlaceMapper {
 			distance,
 			post.getEndDateTime().toLocalDate(),
 			imgUrls
+		);
+	}
+
+	public RecommendPlaceByTimeResponse toRecommendPlaceByTimeResponse(String type,
+		List<RecommendPartnershipPlaceResponse> partnershipPosts, List<RecommendNearByPlaceResponse> nearbyPlaces) {
+
+		return new RecommendPlaceByTimeResponse(type, partnershipPosts, nearbyPlaces);
+	}
+
+	public RecommendPartnershipPlaceResponse toRecommendPartnershipPlaceResponse(StudentCouncilPost post) {
+		return new RecommendPartnershipPlaceResponse(
+			post.getPlace().getPlaceId(),
+			post.getPlace().getPlaceName(),
+			post.getWriter().getCouncilName(),
+			post.getTitle(),
+			post.getPlace().getAddress(),
+			post.getThumbnailImageUrl()
+		);
+	}
+
+	public RecommendNearByPlaceResponse toRecommendNearByPlaceResponse(SavedPlaceInfo savedPlaceInfo,
+		List<String> imageUrl) {
+		return new RecommendNearByPlaceResponse(
+			savedPlaceInfo.placeName(),
+			savedPlaceInfo.placeKey(),
+			savedPlaceInfo.address(),
+			savedPlaceInfo.category(),
+			savedPlaceInfo.link(),
+			savedPlaceInfo.telephone(),
+			savedPlaceInfo.coordinate(),
+			imageUrl
 		);
 	}
 

--- a/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
+++ b/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
@@ -351,11 +351,20 @@ public class PlaceService {
 		Long collegeId = user.getCollege() != null ? user.getCollege().getCollegeId() : null;
 		Long majorId = user.getMajor() != null ? user.getMajor().getMajorId() : null;
 
+		int poolSize = 15;
 		List<StudentCouncilPost> posts = studentCouncilPostRepository.findRandomPartnershipPlace(
-			schoolId, collegeId, majorId, icon, LocalDateTime.now(KST), PageRequest.of(0, 2)
+			schoolId, collegeId, majorId, icon, LocalDateTime.now(KST), PageRequest.of(0, poolSize)
 		);
 
-		return posts.stream()
+		if (posts.isEmpty()) {
+			return List.of();
+		}
+
+		List<StudentCouncilPost> mutablePosts = new ArrayList<>(posts);
+		Collections.shuffle(mutablePosts);
+
+		return mutablePosts.stream()
+			.limit(2)
 			.map(placeMapper::toRecommendPartnershipPlaceResponse)
 			.toList();
 	}

--- a/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
+++ b/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
@@ -2,6 +2,11 @@ package com.campus.campus.domain.place.application.service;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -11,11 +16,18 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.campus.campus.domain.councilpost.application.dto.request.PostRequest;
+import com.campus.campus.domain.councilpost.application.exception.AcademicInfoNotSetException;
+import com.campus.campus.domain.councilpost.domain.entity.StudentCouncilPost;
+import com.campus.campus.domain.councilpost.domain.entity.ThumbnailIcon;
+import com.campus.campus.domain.councilpost.domain.repository.StudentCouncilPostRepository;
 import com.campus.campus.domain.place.application.dto.response.LikeResponse;
+import com.campus.campus.domain.place.application.dto.response.RecommendNearByPlaceResponse;
+import com.campus.campus.domain.place.application.dto.response.RecommendPartnershipPlaceResponse;
+import com.campus.campus.domain.place.application.dto.response.RecommendPlaceByTimeResponse;
 import com.campus.campus.domain.place.application.dto.response.SavedPlaceInfo;
 import com.campus.campus.domain.place.application.dto.response.SearchCandidateResponse;
 import com.campus.campus.domain.place.application.dto.response.geocoder.AddressResponse;
@@ -49,10 +61,21 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class PlaceService {
 
+	private static final LocalTime LUNCH_START = LocalTime.of(11, 30);
+	private static final LocalTime LUNCH_END = LocalTime.of(14, 0);
+	private static final LocalTime CAFE_START = LocalTime.of(14, 0);
+	private static final LocalTime CAFE_END = LocalTime.of(17, 0);
+	private static final LocalTime DINNER_START = LocalTime.of(17, 0);
+	private static final LocalTime DINNER_END = LocalTime.of(20, 0);
+	private static final LocalTime BAR_START = LocalTime.of(20, 0);
+	private static final LocalTime BAR_END = LocalTime.of(23, 0);
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
 	private final NaverMapClient naverMapClient;
 	private final PlaceMapper placeMapper;
 	private final PlaceRepository placeRepository;
 	private final GooglePlaceClient googleClient;
+	private final StudentCouncilPostRepository studentCouncilPostRepository;
 	private final PlaceImagesRepository placeImagesRepository;
 	private final PresignedUrlService presignedUrlService;
 	private final LikedPlacesRepository likedPlacesRepository;
@@ -149,6 +172,29 @@ public class PlaceService {
 		likedPlacesRepository.save(savedLikedPlace);
 
 		return placeMapper.toLikeResponse(place);
+	}
+
+	@Transactional(readOnly = true)
+	public RecommendPlaceByTimeResponse findRecommendations(Long userId, double lat, double lng) {
+		LocalTime now = LocalTime.now(KST);
+		User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+			.orElseThrow(UserNotFoundException::new);
+
+		if (user.isProfileNotCompleted()) {
+			throw new AcademicInfoNotSetException();
+		}
+
+		if (isLunchTime(now)) {
+			return generateResponse(user, lat, lng, ThumbnailIcon.FOOD, "식당", "LUNCH");
+		} else if (isCafeTime(now)) {
+			return generateResponse(user, lat, lng, ThumbnailIcon.CAFE, "카페", "CAFE");
+		} else if (isDinnerTime(now)) {
+			return generateResponse(user, lat, lng, ThumbnailIcon.FOOD, "식당", "DINNER");
+		} else if (isBarTime(now)) {
+			return generateResponse(user, lat, lng, ThumbnailIcon.BAR, "술집", "BAR");
+		} else {
+			return placeMapper.toRecommendPlaceByTimeResponse("잠잘시간입니다.", List.of(), List.of());
+		}
 	}
 
 	private List<SavedPlaceInfo> processSearchResults(NaverSearchResponse naverSearchResponse, int imageLimit) {
@@ -272,6 +318,67 @@ public class PlaceService {
 			.findFirst()
 			.map(AddressResponse.Result::getText)
 			.orElse(null);
+	}
+
+	private boolean isLunchTime(LocalTime now) {
+		return !now.isBefore(LUNCH_START) && now.isBefore(LUNCH_END);
+	}
+
+	private boolean isCafeTime(LocalTime now) {
+		return !now.isBefore(CAFE_START) && !now.isAfter(CAFE_END);
+	}
+
+	private boolean isDinnerTime(LocalTime now) {
+		return !now.isBefore(DINNER_START) && !now.isAfter(DINNER_END);
+	}
+
+	private boolean isBarTime(LocalTime now) {
+		return !now.isBefore(BAR_START) && !now.isAfter(BAR_END);
+	}
+
+	private RecommendPlaceByTimeResponse generateResponse(User user, double lat, double lng, ThumbnailIcon icon,
+		String keyword, String type) {
+		List<RecommendPartnershipPlaceResponse> partnerships = getRandomPartnerships(user, icon);
+
+		List<RecommendNearByPlaceResponse> externalPlaces = getRandomNearByPlaces(lat, lng, keyword);
+
+		return placeMapper.toRecommendPlaceByTimeResponse(type, partnerships, externalPlaces);
+	}
+
+	private List<RecommendPartnershipPlaceResponse> getRandomPartnerships(User user, ThumbnailIcon icon) {
+		Long schoolId = user.getSchool().getSchoolId();
+		Long collegeId = user.getCollege() != null ? user.getCollege().getCollegeId() : null;
+		Long majorId = user.getMajor() != null ? user.getMajor().getMajorId() : null;
+
+		List<StudentCouncilPost> posts = studentCouncilPostRepository.findRandomPartnershipPlace(
+			schoolId, collegeId, majorId, icon, LocalDateTime.now(KST), PageRequest.of(0, 2)
+		);
+
+		return posts.stream()
+			.map(placeMapper::toRecommendPartnershipPlaceResponse)
+			.toList();
+	}
+
+	private List<RecommendNearByPlaceResponse> getRandomNearByPlaces(double lat, double lng, String keyword) {
+		List<SavedPlaceInfo> searchResults = searchByLocationAndKeyword(lat, lng, keyword, 1);
+
+		if (searchResults.isEmpty()) {
+			return List.of();
+		}
+
+		List<SavedPlaceInfo> mutableList = new ArrayList<>(searchResults);
+		Collections.shuffle(mutableList);
+
+		return mutableList.stream()
+			.limit(2)
+			.map(info -> {
+				List<String> imageUrl = (info.imgUrls() != null && !info.imgUrls().isEmpty())
+					? List.of(info.imgUrls().get(0))
+					: Collections.emptyList();
+
+				return placeMapper.toRecommendNearByPlaceResponse(info, imageUrl);
+			})
+			.toList();
 	}
 
 }

--- a/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
+++ b/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
@@ -60,7 +60,7 @@ public class PlaceService {
 	private final ExecutorService executorService;
 	private final GeoCoderClient geoCoderClient;
 
-	public List<SavedPlaceInfo> searchByLocationAndKeyword(double lat, double lng, String keyword) {
+	public List<SavedPlaceInfo> searchByLocationAndKeyword(double lat, double lng, String keyword, int imageLimit) {
 		String searchWord = keyword;
 
 		try {
@@ -80,13 +80,13 @@ public class PlaceService {
 		//네이버에서 특정 장소 기본정보 받아오기
 		NaverSearchResponse naverSearchResponse = naverMapClient.searchPlaces(searchWord, 5);
 
-		return processSearchResults(naverSearchResponse);
+		return processSearchResults(naverSearchResponse, imageLimit);
 	}
 
-	public List<SavedPlaceInfo> searchByKeyword(String keyword) {
+	public List<SavedPlaceInfo> searchByKeyword(String keyword, int imageLimit) {
 		NaverSearchResponse naverSearchResponse = naverMapClient.searchPlaces(keyword, 5);
 
-		return processSearchResults(naverSearchResponse);
+		return processSearchResults(naverSearchResponse, imageLimit);
 	}
 
 	public Place findOrCreatePlace(SavedPlaceInfo place) {
@@ -151,7 +151,7 @@ public class PlaceService {
 		return placeMapper.toLikeResponse(place);
 	}
 
-	private List<SavedPlaceInfo> processSearchResults(NaverSearchResponse naverSearchResponse) {
+	private List<SavedPlaceInfo> processSearchResults(NaverSearchResponse naverSearchResponse, int imageLimit) {
 		List<SearchCandidateResponse> candidates = naverSearchResponse.items().stream()
 			.map(item -> {
 				String name = stripHtml(item.title());
@@ -174,7 +174,7 @@ public class PlaceService {
 			));
 
 		List<CompletableFuture<SavedPlaceInfo>> futures = candidates.stream()
-			.map(response -> CompletableFuture.supplyAsync(() -> convertToSavedPlaceInfo(response, images),
+			.map(response -> CompletableFuture.supplyAsync(() -> convertToSavedPlaceInfo(response, images, imageLimit),
 					executorService)
 				.completeOnTimeout(fallback(response), 4, TimeUnit.SECONDS)
 				.exceptionally(ex -> fallback(response)))
@@ -184,10 +184,11 @@ public class PlaceService {
 		return futures.stream().map(CompletableFuture::join).toList();
 	}
 
-	private SavedPlaceInfo convertToSavedPlaceInfo(SearchCandidateResponse response, Map<String, List<String>> images) {
+	private SavedPlaceInfo convertToSavedPlaceInfo(SearchCandidateResponse response, Map<String, List<String>> images,
+		int imageLimit) {
 		List<String> cached = images.getOrDefault(response.placeKey(), List.of());
 		List<String> placeImages = !cached.isEmpty()
-			? cached : googleClient.fetchImages(response.name(), response.address(), 3);
+			? cached : googleClient.fetchImages(response.name(), response.address(), imageLimit);
 
 		return placeMapper.toSavedPlaceInfo(response.item(), response.name(), response.placeKey(),
 			response.naverPlaceUrl(), placeImages == null ? List.of() : placeImages

--- a/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
+++ b/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
@@ -326,15 +326,15 @@ public class PlaceService {
 	}
 
 	private boolean isCafeTime(LocalTime now) {
-		return !now.isBefore(CAFE_START) && !now.isAfter(CAFE_END);
+		return !now.isBefore(CAFE_START) && now.isBefore(CAFE_END);
 	}
 
 	private boolean isDinnerTime(LocalTime now) {
-		return !now.isBefore(DINNER_START) && !now.isAfter(DINNER_END);
+		return !now.isBefore(DINNER_START) && now.isBefore(DINNER_END);
 	}
 
 	private boolean isBarTime(LocalTime now) {
-		return !now.isBefore(BAR_START) && !now.isAfter(BAR_END);
+		return !now.isBefore(BAR_START) && now.isBefore(BAR_END);
 	}
 
 	private RecommendPlaceByTimeResponse generateResponse(User user, double lat, double lng, ThumbnailIcon icon,

--- a/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
+++ b/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
@@ -66,9 +66,9 @@ public class PlaceService {
 	private static final LocalTime CAFE_START = LocalTime.of(14, 0);
 	private static final LocalTime CAFE_END = LocalTime.of(17, 0);
 	private static final LocalTime DINNER_START = LocalTime.of(17, 0);
-	private static final LocalTime DINNER_END = LocalTime.of(23, 0);
-	private static final LocalTime BAR_START = LocalTime.of(23, 0);
-	private static final LocalTime BAR_END = LocalTime.of(0, 0);
+	private static final LocalTime DINNER_END = LocalTime.of(20, 0);
+	private static final LocalTime BAR_START = LocalTime.of(20, 0);
+	private static final LocalTime BAR_END = LocalTime.of(23, 30);
 	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
 	private final NaverMapClient naverMapClient;

--- a/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
+++ b/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
@@ -66,9 +66,9 @@ public class PlaceService {
 	private static final LocalTime CAFE_START = LocalTime.of(14, 0);
 	private static final LocalTime CAFE_END = LocalTime.of(17, 0);
 	private static final LocalTime DINNER_START = LocalTime.of(17, 0);
-	private static final LocalTime DINNER_END = LocalTime.of(20, 0);
-	private static final LocalTime BAR_START = LocalTime.of(20, 0);
-	private static final LocalTime BAR_END = LocalTime.of(23, 0);
+	private static final LocalTime DINNER_END = LocalTime.of(23, 0);
+	private static final LocalTime BAR_START = LocalTime.of(23, 0);
+	private static final LocalTime BAR_END = LocalTime.of(0, 0);
 	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
 	private final NaverMapClient naverMapClient;
@@ -78,6 +78,7 @@ public class PlaceService {
 	private final StudentCouncilPostRepository studentCouncilPostRepository;
 	private final PlaceImagesRepository placeImagesRepository;
 	private final PresignedUrlService presignedUrlService;
+	private final RedisPlaceCacheService redisPlaceCacheService;
 	private final LikedPlacesRepository likedPlacesRepository;
 	private final UserRepository userRepository;
 	private final ExecutorService executorService;
@@ -360,7 +361,18 @@ public class PlaceService {
 	}
 
 	private List<RecommendNearByPlaceResponse> getRandomNearByPlaces(double lat, double lng, String keyword) {
-		List<SavedPlaceInfo> searchResults = searchByLocationAndKeyword(lat, lng, keyword, 1);
+		Optional<List<SavedPlaceInfo>> cachedPlaces = redisPlaceCacheService.getCachedPlaces(lat, lng, keyword);
+
+		List<SavedPlaceInfo> searchResults;
+
+		if (cachedPlaces.isPresent()) {
+			searchResults = cachedPlaces.get();
+		} else {
+			searchResults = searchByLocationAndKeyword(lat, lng, keyword, 1);
+			if (!searchResults.isEmpty()) {
+				redisPlaceCacheService.cachePlaces(keyword, lat, lng, searchResults);
+			}
+		}
 
 		if (searchResults.isEmpty()) {
 			return List.of();

--- a/src/main/java/com/campus/campus/domain/place/application/service/RedisPlaceCacheService.java
+++ b/src/main/java/com/campus/campus/domain/place/application/service/RedisPlaceCacheService.java
@@ -1,0 +1,68 @@
+package com.campus.campus.domain.place.application.service;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.campus.campus.domain.place.application.dto.response.SavedPlaceInfo;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RedisPlaceCacheService {
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final ObjectMapper objectMapper;
+
+	private static final Duration CACHE_TTL = Duration.ofHours(1);
+	private static final double GRID_PRECISION = 1000.0;
+
+	public void cachePlaces(String keyword, double lat, double lng, List<SavedPlaceInfo> places) {
+		if (places == null || places.isEmpty()) {
+			return;
+		}
+
+		String key = generateKey(lat, lng, keyword);
+		try {
+			String jsonValue = objectMapper.writeValueAsString(places);
+			redisTemplate.opsForValue().set(key, jsonValue, CACHE_TTL);
+			log.info("[Redis] Cache Saved: key={}", key);
+		} catch (Exception e) {
+			log.warn("[Redis] Cache Save Failed: key={}", key, e);
+		}
+	}
+
+	public Optional<List<SavedPlaceInfo>> getCachedPlaces(double lat, double lng, String keyword) {
+		String key = generateKey(lat, lng, keyword);
+
+		Object value = redisTemplate.opsForValue().get(key);
+		if (value == null) {
+			return Optional.empty();
+		}
+
+		try {
+			String jsonValue = String.valueOf(value);
+			List<SavedPlaceInfo> places = objectMapper.readValue(jsonValue, new TypeReference<List<SavedPlaceInfo>>() {
+			});
+			log.info("[Redis] Cache Hit: key={}", key);
+			return Optional.of(places);
+		} catch (Exception e) {
+			log.warn("[Redis] Cache Parsing Failed: key={}", key, e);
+			return Optional.empty();
+		}
+	}
+
+	private String generateKey(double lat, double lng, String keyword) {
+		double roundedLat = Math.round(lat * GRID_PRECISION) / GRID_PRECISION;
+		double roundedLng = Math.round(lng * GRID_PRECISION) / GRID_PRECISION;
+
+		return String.format("places:recommend:%s:%s:%s", keyword, roundedLat, roundedLng);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/place/infrastructure/google/GooglePlaceClient.java
+++ b/src/main/java/com/campus/campus/domain/place/infrastructure/google/GooglePlaceClient.java
@@ -51,7 +51,7 @@ public class GooglePlaceClient {
 	/*
 	 * 장소 이름 + 주소를 기준으로 google places에서 이미지 URL 목록을 가져옴
 	 */
-	public List<String> fetchImages(String name, String address, int limit) {
+	public List<String> fetchImages(String name, String address, int imageLimit) {
 		boolean acquired = false;
 		try {
 			acquired = googleApiSemaphore.tryAcquire(5, TimeUnit.SECONDS);
@@ -73,7 +73,7 @@ public class GooglePlaceClient {
 
 			//imageURL 생성
 			List<String> imageUrls = photoRefs.stream()
-				.limit(3)
+				.limit(imageLimit)
 				.map(this::buildPhotoUrl)
 				.toList();
 

--- a/src/main/java/com/campus/campus/domain/place/presentation/PlaceController.java
+++ b/src/main/java/com/campus/campus/domain/place/presentation/PlaceController.java
@@ -55,7 +55,7 @@ public class PlaceController {
 		)
 		@RequestParam double lng
 	) {
-		List<SavedPlaceInfo> searchResponse = placeService.searchByLocationAndKeyword(lat, lng, keyword);
+		List<SavedPlaceInfo> searchResponse = placeService.searchByLocationAndKeyword(lat, lng, keyword, 3);
 
 		return CommonResponse.success(PlaceResponseCode.PLACE_SEARCH_SUCCESS, searchResponse);
 	}
@@ -63,7 +63,7 @@ public class PlaceController {
 	@GetMapping("/search/keyword")
 	@Operation(summary = "키워드 기반 장소 검색")
 	public CommonResponse<List<SavedPlaceInfo>> getPlaceInfoWithKeyword(@RequestParam String keyword) {
-		List<SavedPlaceInfo> searchResponse = placeService.searchByKeyword(keyword);
+		List<SavedPlaceInfo> searchResponse = placeService.searchByKeyword(keyword, 3);
 
 		return CommonResponse.success(PlaceResponseCode.PLACE_SEARCH_SUCCESS, searchResponse);
 	}

--- a/src/main/java/com/campus/campus/domain/place/presentation/PlaceController.java
+++ b/src/main/java/com/campus/campus/domain/place/presentation/PlaceController.java
@@ -202,6 +202,6 @@ public class PlaceController {
 	) {
 		RecommendPlaceByTimeResponse response = placeService.findRecommendations(userId, lat, lng);
 
-		return CommonResponse.success(PlaceResponseCode.PLACE_SEARCH_SUCCESS, response);
+		return CommonResponse.success(PlaceResponseCode.GET_RANDOM_PLACE_SUCCESS, response);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/place/presentation/PlaceController.java
+++ b/src/main/java/com/campus/campus/domain/place/presentation/PlaceController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.campus.campus.domain.place.application.dto.response.PartnershipPinResponse;
+import com.campus.campus.domain.place.application.dto.response.RecommendPlaceByTimeResponse;
 import com.campus.campus.domain.place.application.service.PartnershipPlaceService;
 import com.campus.campus.domain.place.application.dto.response.LikeResponse;
 import com.campus.campus.domain.place.application.dto.response.SavedPlaceInfo;
@@ -130,7 +131,8 @@ public class PlaceController {
 			example = "5"
 		)
 		@RequestParam(defaultValue = "5") int size) {
-		List<PartnershipResponse> response = partnershipPlaceService.getPartnershipPlaces(userId, cursor, size, lat, lng);
+		List<PartnershipResponse> response = partnershipPlaceService.getPartnershipPlaces(userId, cursor, size, lat,
+			lng);
 
 		return CommonResponse.success(PlaceResponseCode.CHECK_PARTNERSHIP_PLACES_SUCCESS, response);
 	}
@@ -189,5 +191,17 @@ public class PlaceController {
 		return CommonResponse.success(
 			PlaceResponseCode.CHECK_ONE_PARTNERSHIP_PLACE_SUCCESS,
 			partnershipPlaceService.getPartnershipDetail(postId, userId, lat, lng));
+	}
+
+	@GetMapping("/random")
+	@Operation(summary = "시간대별 랜덤 장소 추천 (제휴 장소 2, 랜덤 장소 2) (홈화면)")
+	public CommonResponse<RecommendPlaceByTimeResponse> getRandomPlaceByTime(
+		@CurrentUserId Long userId,
+		@RequestParam double lat,
+		@RequestParam double lng
+	) {
+		RecommendPlaceByTimeResponse response = placeService.findRecommendations(userId, lat, lng);
+
+		return CommonResponse.success(PlaceResponseCode.PLACE_SEARCH_SUCCESS, response);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/place/presentation/PlaceResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/place/presentation/PlaceResponseCode.java
@@ -14,7 +14,8 @@ public enum PlaceResponseCode implements ResponseCodeInterface {
 	PLACE_SEARCH_SUCCESS(200, HttpStatus.OK, "키워드 장소 검색이 성공적으로 완료되었습니다."),
 	CHECK_PARTNERSHIP_PLACE_SUCCESS(200, HttpStatus.OK, "제휴 장소 조회가 완료되었습니다."),
 	CHECK_PARTNERSHIP_PLACES_SUCCESS(200, HttpStatus.OK, "제휴 장소 리스트 조회가 완료되었습니다."),
-	CHECK_ONE_PARTNERSHIP_PLACE_SUCCESS(200, HttpStatus.OK, "제휴 장소 단건 조회가 완료되었습니다.");
+	CHECK_ONE_PARTNERSHIP_PLACE_SUCCESS(200, HttpStatus.OK, "제휴 장소 단건 조회가 완료되었습니다."),
+	GET_RANDOM_PLACE_SUCCESS(200, HttpStatus.OK, "시간대별 랜덤 장소 조회가 완료되었습니다.");
 
 	private final int code;
 	private final HttpStatus status;


### PR DESCRIPTION
## 🔀 변경 내용
- 시간대별 랜덤 장소 추천 기능 구현했습니다.

## ✅ 작업 항목
- [ ] 시간대별 랜덤 장소 추천 기능 구현. 시간대별로 로그인한 유저가 속한 학적정보 범위 내의 학생회가 올린 제휴가 등록된 장소 2개와, 현재 위치를 기반으로 한 장소 2개를 랜덤으로 조회합니다.
오전 11시 30분 - 오후 2시: 밥집 추천
오후 2시 - 오후 5시: 카페 추천
오후 5시 - 오후 8시: 밥집 추천
오후 8시 - 오후 11시: 술집 추천
추가적으로 레디스 캐시를 적용해 랜덤 장소 검색 시 Naver/Google API 호출 수를 줄이고자 했습니다.
좌표의 경우 소수점 3자리에 반올림을 진행하며 redis에 후보군 리스트를 고정합니다. 그 후 1시간 동안은 사용자가 새로고침할 때마다 고정된 해당 리스트 안에서 랜덤으로 2개를 뽑아서 보여주게 됩니다.
이렇게 할 경우 가까운 위치에 있는 유저들이 해당 기능을 사용하게 되면 불필요한 외부 api의 호출을 줄일 수 있게 됩니다.

## 📸 스크린샷 (선택)
### 시간대별 랜덤 장소 추천 기능 호출 시 다음과 같이 제휴가 등록된 장소 2개와 현재 위치를 기반으로 한 장소 2개가 랜덤으로 검색되어 한번에 조회됩니다.
<img width="1468" height="579" alt="image" src="https://github.com/user-attachments/assets/6b954dd8-8191-45ec-8832-335eb87bdb46" />
<img width="1475" height="585" alt="image" src="https://github.com/user-attachments/assets/5a3ac4cf-0a51-4855-b057-92508592dba4" />

## 📎 참고 이슈
관련 이슈 번호 #61 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 시간대별 맞춤 장소 추천 추가: 점심/카페/저녁/바 시간대에 맞춘 제휴 게시물 및 주변 장소 통합 랜덤 추천 제공
  * 신규 추천 API 엔드포인트 추가로 위치 기반 시간대별 추천 조회 가능

* **성능 개선**
  * 검색결과당 이미지 표시 수 제한(기본 3장) 적용
  * Redis 기반 장소 캐싱 도입으로 응답 속도 및 리소스 효율 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->