### PR TITLE
Feat/#63 스탬프 기능 구현

### DIFF
--- a/src/main/java/com/campus/campus/domain/manager/application/dto/request/RewardRequest.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/dto/request/RewardRequest.java
@@ -1,0 +1,11 @@
+package com.campus.campus.domain.manager.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record RewardRequest(
+	@NotBlank
+	@Schema(description = "보상으로 지급 이미지 url", example = "https://www.example.com.png")
+	String rewardImageUrl
+) {
+}

--- a/src/main/java/com/campus/campus/domain/manager/application/dto/response/StampRewardNeededUserListResponse.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/dto/response/StampRewardNeededUserListResponse.java
@@ -1,0 +1,18 @@
+package com.campus.campus.domain.manager.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record StampRewardNeededUserListResponse(
+	@Schema(description = "보상 지급이 필요한 사용자 ID", example = "1")
+	Long userId,
+
+	@Schema(description = "보상 지급이 필요한 사용자 이름", example = "한승현")
+	String nickname,
+
+	@Schema(description = "사용자의 스탬프 수", example = "10")
+	int stampCount,
+
+	@Schema(description = "사용자가 보상이 필요한지 여부", example = "true")
+	boolean rewardNeeded
+) {
+}

--- a/src/main/java/com/campus/campus/domain/manager/application/mapper/ManagerMapper.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/mapper/ManagerMapper.java
@@ -3,12 +3,14 @@ package com.campus.campus.domain.manager.application.mapper;
 import org.springframework.stereotype.Component;
 
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
+import com.campus.campus.domain.manager.application.dto.request.RewardRequest;
 import com.campus.campus.domain.manager.application.dto.response.CertifyRequestCouncilResponse;
 import com.campus.campus.domain.manager.application.dto.response.CouncilApproveOrDenyResponse;
 import com.campus.campus.domain.manager.application.dto.response.CertifyRequestCouncilListResponse;
 import com.campus.campus.domain.manager.application.dto.response.ManagerLoginResponse;
 import com.campus.campus.domain.manager.application.dto.response.StampRewardNeededUserListResponse;
 import com.campus.campus.domain.manager.domain.entity.Manager;
+import com.campus.campus.domain.stamp.domain.entity.Reward;
 import com.campus.campus.domain.user.domain.entity.User;
 
 import lombok.RequiredArgsConstructor;
@@ -59,5 +61,12 @@ public class ManagerMapper {
 			stampCount,
 			user.isRewardNeeded()
 		);
+	}
+
+	public Reward createReward(User user, RewardRequest rewardRequest) {
+		return Reward.builder()
+			.user(user)
+			.rewardImageUrl(rewardRequest.rewardImageUrl())
+			.build();
 	}
 }

--- a/src/main/java/com/campus/campus/domain/manager/application/mapper/ManagerMapper.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/mapper/ManagerMapper.java
@@ -7,7 +7,9 @@ import com.campus.campus.domain.manager.application.dto.response.CertifyRequestC
 import com.campus.campus.domain.manager.application.dto.response.CouncilApproveOrDenyResponse;
 import com.campus.campus.domain.manager.application.dto.response.CertifyRequestCouncilListResponse;
 import com.campus.campus.domain.manager.application.dto.response.ManagerLoginResponse;
+import com.campus.campus.domain.manager.application.dto.response.StampRewardNeededUserListResponse;
 import com.campus.campus.domain.manager.domain.entity.Manager;
+import com.campus.campus.domain.user.domain.entity.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -43,6 +45,19 @@ public class ManagerMapper {
 			studentCouncil.getId(),
 			studentCouncil.getCouncilName(),
 			studentCouncil.getElectionImageUrl()
+		);
+	}
+
+	public StampRewardNeededUserListResponse toStampRewardNeededUserListResponse(User user, int stampCount) {
+		String nickname = user.getCampusNickname();
+		if (nickname == null || nickname.isBlank()) {
+			nickname = user.getNickname();
+		}
+		return new StampRewardNeededUserListResponse(
+			user.getId(),
+			nickname,
+			stampCount,
+			user.isRewardNeeded()
 		);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
@@ -108,12 +108,14 @@ public class ManagerService {
 	}
 
 	public List<StampRewardNeededUserListResponse> getStampRewardNeededUserList() {
-		List<User> rewardNeededUsers = userRepository.findAllByRewardNeededIsTrueAndDeletedAtIsNull();
+		List<Object[]> rewardNeededUsers = userRepository.findRewardNeededUsersWithStampCount();
 
 		return rewardNeededUsers.stream()
-			.map(user -> {
-					int stampCount = stampRepository.countByUser(user);
-					return managerMapper.toStampRewardNeededUserListResponse(user, stampCount);
+			.map(rewardNeededUser -> {
+					User user = (User)rewardNeededUser[0];
+					Long count = (Long)rewardNeededUser[1];
+
+					return managerMapper.toStampRewardNeededUserListResponse(user, count.intValue());
 				}
 			).toList();
 	}

--- a/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
@@ -18,11 +18,15 @@ import com.campus.campus.domain.manager.application.dto.response.CertifyRequestC
 import com.campus.campus.domain.manager.application.dto.response.CouncilApproveOrDenyResponse;
 import com.campus.campus.domain.manager.application.dto.response.CertifyRequestCouncilListResponse;
 import com.campus.campus.domain.manager.application.dto.response.ManagerLoginResponse;
+import com.campus.campus.domain.manager.application.dto.response.StampRewardNeededUserListResponse;
 import com.campus.campus.domain.manager.application.exception.ManagerNotFoundException;
 import com.campus.campus.domain.manager.application.exception.PasswordNotCorrectException;
 import com.campus.campus.domain.manager.application.mapper.ManagerMapper;
 import com.campus.campus.domain.manager.domain.entity.Manager;
 import com.campus.campus.domain.manager.domain.repository.ManagerRepository;
+import com.campus.campus.domain.stamp.domain.repository.StampRepository;
+import com.campus.campus.domain.user.domain.entity.User;
+import com.campus.campus.domain.user.domain.repository.UserRepository;
 import com.campus.campus.global.util.jwt.JwtProvider;
 import com.campus.campus.global.util.jwt.application.service.RedisTokenService;
 
@@ -34,6 +38,8 @@ import lombok.RequiredArgsConstructor;
 public class ManagerService {
 	private final StudentCouncilRepository studentCouncilRepository;
 	private final ManagerRepository managerRepository;
+	private final UserRepository userRepository;
+	private final StampRepository stampRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final JwtProvider jwtProvider;
 	private final RedisTokenService redisTokenService;
@@ -94,6 +100,17 @@ public class ManagerService {
 			.orElseThrow(StudentCouncilNotFoundException::new);
 
 		return managerMapper.toCertifyRequestCouncilResponse(studentCouncil);
+	}
+
+	public List<StampRewardNeededUserListResponse> getStampRewardNeededUserList() {
+		List<User> rewardNeededUsers = userRepository.findAllByRewardNeededIsTrueAndDeletedAtIsNull();
+
+		return rewardNeededUsers.stream()
+			.map(user -> {
+					int stampCount = stampRepository.countByUser(user);
+					return managerMapper.toStampRewardNeededUserListResponse(user, stampCount);
+				}
+			).toList();
 	}
 
 	private void sendCouncilApprovedMail(String to) {

--- a/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
@@ -27,7 +27,6 @@ import com.campus.campus.domain.manager.domain.entity.Manager;
 import com.campus.campus.domain.manager.domain.repository.ManagerRepository;
 import com.campus.campus.domain.stamp.domain.entity.Reward;
 import com.campus.campus.domain.stamp.domain.repository.RewardRepository;
-import com.campus.campus.domain.stamp.domain.repository.StampRepository;
 import com.campus.campus.domain.user.application.exception.UserNotFoundException;
 import com.campus.campus.domain.user.domain.entity.User;
 import com.campus.campus.domain.user.domain.repository.UserRepository;
@@ -43,7 +42,6 @@ public class ManagerService {
 	private final StudentCouncilRepository studentCouncilRepository;
 	private final ManagerRepository managerRepository;
 	private final UserRepository userRepository;
-	private final StampRepository stampRepository;
 	private final RewardRepository rewardRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final JwtProvider jwtProvider;

--- a/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
@@ -14,6 +14,7 @@ import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.council.domain.repository.StudentCouncilRepository;
 import com.campus.campus.domain.manager.application.dto.request.CouncilApproveOrDenyRequest;
 import com.campus.campus.domain.manager.application.dto.request.ManagerLoginRequest;
+import com.campus.campus.domain.manager.application.dto.request.RewardRequest;
 import com.campus.campus.domain.manager.application.dto.response.CertifyRequestCouncilResponse;
 import com.campus.campus.domain.manager.application.dto.response.CouncilApproveOrDenyResponse;
 import com.campus.campus.domain.manager.application.dto.response.CertifyRequestCouncilListResponse;
@@ -24,7 +25,10 @@ import com.campus.campus.domain.manager.application.exception.PasswordNotCorrect
 import com.campus.campus.domain.manager.application.mapper.ManagerMapper;
 import com.campus.campus.domain.manager.domain.entity.Manager;
 import com.campus.campus.domain.manager.domain.repository.ManagerRepository;
+import com.campus.campus.domain.stamp.domain.entity.Reward;
+import com.campus.campus.domain.stamp.domain.repository.RewardRepository;
 import com.campus.campus.domain.stamp.domain.repository.StampRepository;
+import com.campus.campus.domain.user.application.exception.UserNotFoundException;
 import com.campus.campus.domain.user.domain.entity.User;
 import com.campus.campus.domain.user.domain.repository.UserRepository;
 import com.campus.campus.global.util.jwt.JwtProvider;
@@ -40,6 +44,7 @@ public class ManagerService {
 	private final ManagerRepository managerRepository;
 	private final UserRepository userRepository;
 	private final StampRepository stampRepository;
+	private final RewardRepository rewardRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final JwtProvider jwtProvider;
 	private final RedisTokenService redisTokenService;
@@ -111,6 +116,18 @@ public class ManagerService {
 					return managerMapper.toStampRewardNeededUserListResponse(user, stampCount);
 				}
 			).toList();
+	}
+
+	@Transactional
+	public void grantRewardToUser(Long userId, RewardRequest rewardRequest) {
+		User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+			.orElseThrow(UserNotFoundException::new);
+
+		Reward reward = managerMapper.createReward(user, rewardRequest);
+
+		rewardRepository.save(reward);
+
+		user.updateRewardNeeded(false);
 	}
 
 	private void sendCouncilApprovedMail(String to) {

--- a/src/main/java/com/campus/campus/domain/manager/presentation/ManagerController.java
+++ b/src/main/java/com/campus/campus/domain/manager/presentation/ManagerController.java
@@ -83,7 +83,10 @@ public class ManagerController {
 	@PostMapping("reward/grant/{userId}")
 	@PreAuthorize("hasRole('MANAGER')")
 	@Operation(summary = "스탬프 보상 지급")
-	public CommonResponse<Void> grantRewardToUser(@PathVariable Long userId, RewardRequest rewardRequest) {
+	public CommonResponse<Void> grantRewardToUser(
+		@PathVariable Long userId,
+		@Valid @RequestBody RewardRequest rewardRequest
+	) {
 		managerService.grantRewardToUser(userId, rewardRequest);
 
 		return CommonResponse.success(ManagerResponseCode.GRANT_REWARD_SUCCESS);

--- a/src/main/java/com/campus/campus/domain/manager/presentation/ManagerController.java
+++ b/src/main/java/com/campus/campus/domain/manager/presentation/ManagerController.java
@@ -17,6 +17,7 @@ import com.campus.campus.domain.manager.application.dto.response.CertifyRequestC
 import com.campus.campus.domain.manager.application.dto.response.CouncilApproveOrDenyResponse;
 import com.campus.campus.domain.manager.application.dto.response.CertifyRequestCouncilListResponse;
 import com.campus.campus.domain.manager.application.dto.response.ManagerLoginResponse;
+import com.campus.campus.domain.manager.application.dto.response.StampRewardNeededUserListResponse;
 import com.campus.campus.domain.manager.application.service.ManagerService;
 import com.campus.campus.global.common.response.CommonResponse;
 
@@ -67,5 +68,14 @@ public class ManagerController {
 		List<CertifyRequestCouncilListResponse> responses = managerService.getCertifyRequestCouncils();
 
 		return CommonResponse.success(ManagerResponseCode.CERTIFY_REQUEST_LIST_SUCCESS, responses);
+	}
+
+	@GetMapping("/reward/need/users")
+	@PreAuthorize("hasRole('MANAGER')")
+	@Operation(summary = "스탬프 보상이 필요한 유저 목록 조회")
+	public CommonResponse<List<StampRewardNeededUserListResponse>> getStampRewardNeededUserList() {
+		List<StampRewardNeededUserListResponse> responses = managerService.getStampRewardNeededUserList();
+
+		return CommonResponse.success(ManagerResponseCode.REWARD_NEEDED_USER_LIST_SUCCESS, responses);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/manager/presentation/ManagerController.java
+++ b/src/main/java/com/campus/campus/domain/manager/presentation/ManagerController.java
@@ -71,7 +71,7 @@ public class ManagerController {
 		return CommonResponse.success(ManagerResponseCode.CERTIFY_REQUEST_LIST_SUCCESS, responses);
 	}
 
-	@GetMapping("/reward/need/users")
+	@GetMapping("/rewards/necessary-users")
 	@PreAuthorize("hasRole('MANAGER')")
 	@Operation(summary = "스탬프 보상이 필요한 유저 목록 조회")
 	public CommonResponse<List<StampRewardNeededUserListResponse>> getStampRewardNeededUserList() {

--- a/src/main/java/com/campus/campus/domain/manager/presentation/ManagerController.java
+++ b/src/main/java/com/campus/campus/domain/manager/presentation/ManagerController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.campus.campus.domain.manager.application.dto.request.CouncilApproveOrDenyRequest;
 import com.campus.campus.domain.manager.application.dto.request.ManagerLoginRequest;
+import com.campus.campus.domain.manager.application.dto.request.RewardRequest;
 import com.campus.campus.domain.manager.application.dto.response.CertifyRequestCouncilResponse;
 import com.campus.campus.domain.manager.application.dto.response.CouncilApproveOrDenyResponse;
 import com.campus.campus.domain.manager.application.dto.response.CertifyRequestCouncilListResponse;
@@ -77,5 +78,14 @@ public class ManagerController {
 		List<StampRewardNeededUserListResponse> responses = managerService.getStampRewardNeededUserList();
 
 		return CommonResponse.success(ManagerResponseCode.REWARD_NEEDED_USER_LIST_SUCCESS, responses);
+	}
+
+	@PostMapping("reward/grant/{userId}")
+	@PreAuthorize("hasRole('MANAGER')")
+	@Operation(summary = "스탬프 보상 지급")
+	public CommonResponse<Void> grantRewardToUser(@PathVariable Long userId, RewardRequest rewardRequest) {
+		managerService.grantRewardToUser(userId, rewardRequest);
+
+		return CommonResponse.success(ManagerResponseCode.GRANT_REWARD_SUCCESS);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/manager/presentation/ManagerResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/manager/presentation/ManagerResponseCode.java
@@ -14,7 +14,8 @@ public enum ManagerResponseCode implements ResponseCodeInterface {
 	COUNCIL_APPROVE_OR_DENY_SUCCESS(200, HttpStatus.OK, "학생회 승인 혹은 거부 및 메일 전송에 성공했습니다."),
 	CERTIFY_REQUEST_LIST_SUCCESS(200, HttpStatus.OK, "학생회 인증 요청 목록 조회에 성공했습니다."),
 	CERTIFY_REQUEST_ELECTION_IMAGE_SUCCESS(200, HttpStatus.OK, "해당 학생회 인증 요청 당선 사진 조회에 성공했습니다."),
-	REWARD_NEEDED_USER_LIST_SUCCESS(200, HttpStatus.OK, "스탬프 보상이 필요한 유저 목록 조회에 성공했습니다.");
+	REWARD_NEEDED_USER_LIST_SUCCESS(200, HttpStatus.OK, "스탬프 보상이 필요한 유저 목록 조회에 성공했습니다."),
+	GRANT_REWARD_SUCCESS(200, HttpStatus.OK, "스탬프 보상 지급에 성공했습니다.");
 
 	private final int code;
 	private final HttpStatus status;

--- a/src/main/java/com/campus/campus/domain/manager/presentation/ManagerResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/manager/presentation/ManagerResponseCode.java
@@ -13,7 +13,8 @@ public enum ManagerResponseCode implements ResponseCodeInterface {
 	MANAGER_LOGIN_SUCCESS(200, HttpStatus.OK, "관리자 로그인에 성공했습니다."),
 	COUNCIL_APPROVE_OR_DENY_SUCCESS(200, HttpStatus.OK, "학생회 승인 혹은 거부 및 메일 전송에 성공했습니다."),
 	CERTIFY_REQUEST_LIST_SUCCESS(200, HttpStatus.OK, "학생회 인증 요청 목록 조회에 성공했습니다."),
-	CERTIFY_REQUEST_ELECTION_IMAGE_SUCCESS(200, HttpStatus.OK, "해당 학생회 인증 요청 당선 사진 조회에 성공했습니다.");
+	CERTIFY_REQUEST_ELECTION_IMAGE_SUCCESS(200, HttpStatus.OK, "해당 학생회 인증 요청 당선 사진 조회에 성공했습니다."),
+	REWARD_NEEDED_USER_LIST_SUCCESS(200, HttpStatus.OK, "스탬프 보상이 필요한 유저 목록 조회에 성공했습니다.");
 
 	private final int code;
 	private final HttpStatus status;

--- a/src/main/java/com/campus/campus/domain/review/application/dto/response/ReviewCreateResult.java
+++ b/src/main/java/com/campus/campus/domain/review/application/dto/response/ReviewCreateResult.java
@@ -6,6 +6,6 @@ import lombok.Builder;
 public record ReviewCreateResult(
 	boolean isFirstReviewOfPlace,
 	int userReviewCountOfPlace,
-	int NumberOfUserStamp
+	int numberOfUserStamp
 ) {
 }

--- a/src/main/java/com/campus/campus/domain/review/application/dto/response/ReviewCreateResult.java
+++ b/src/main/java/com/campus/campus/domain/review/application/dto/response/ReviewCreateResult.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 @Builder
 public record ReviewCreateResult(
 	boolean isFirstReviewOfPlace,
-	int userReviewCountOfPlace
-	// int NumberOfUserStamp,
+	int userReviewCountOfPlace,
+	int NumberOfUserStamp
 ) {
 }

--- a/src/main/java/com/campus/campus/domain/review/application/mapper/ReviewMapper.java
+++ b/src/main/java/com/campus/campus/domain/review/application/mapper/ReviewMapper.java
@@ -92,7 +92,7 @@ public class ReviewMapper {
 		return ReviewCreateResult.builder()
 			.isFirstReviewOfPlace(isFirstReviewOfPlace)
 			.userReviewCountOfPlace((int)userReviewCountOfPlace)
-			.NumberOfUserStamp(numberOfUserStamp)
+			.numberOfUserStamp(numberOfUserStamp)
 			.build();
 	}
 

--- a/src/main/java/com/campus/campus/domain/review/application/mapper/ReviewMapper.java
+++ b/src/main/java/com/campus/campus/domain/review/application/mapper/ReviewMapper.java
@@ -87,11 +87,12 @@ public class ReviewMapper {
 			.build();
 	}
 
-	public ReviewCreateResult toReviewCreateResult(boolean isFirstReviewOfPlace, long userReviewCountOfPlace) {
+	public ReviewCreateResult toReviewCreateResult(boolean isFirstReviewOfPlace, long userReviewCountOfPlace,
+		int numberOfUserStamp) {
 		return ReviewCreateResult.builder()
 			.isFirstReviewOfPlace(isFirstReviewOfPlace)
 			.userReviewCountOfPlace((int)userReviewCountOfPlace)
-			//스탬프 추가 예정
+			.NumberOfUserStamp(numberOfUserStamp)
 			.build();
 	}
 

--- a/src/main/java/com/campus/campus/domain/review/application/service/ReviewService.java
+++ b/src/main/java/com/campus/campus/domain/review/application/service/ReviewService.java
@@ -35,6 +35,7 @@ import com.campus.campus.domain.review.domain.repository.ReviewRepository;
 import com.campus.campus.domain.school.domain.entity.College;
 import com.campus.campus.domain.school.domain.entity.Major;
 import com.campus.campus.domain.school.domain.entity.School;
+import com.campus.campus.domain.stamp.domain.repository.StampRepository;
 import com.campus.campus.domain.user.application.exception.UserNotFoundException;
 import com.campus.campus.domain.user.domain.entity.User;
 import com.campus.campus.domain.user.domain.repository.UserRepository;
@@ -55,6 +56,7 @@ public class ReviewService {
 	private final ReviewImageRepository reviewImageRepository;
 	private final PresignedUrlService presignedUrlService;
 	private final StudentCouncilPostRepository studentCouncilPostRepository;
+	private final StampRepository stampRepository;
 
 	@Transactional
 	public ReviewCreateResponse writeReview(ReviewRequest request, Long userId) {
@@ -65,7 +67,6 @@ public class ReviewService {
 			throw new PostImageLimitExceededException();
 		}
 
-		//place 객체 생성
 		Place place = placeService.findOrCreatePlace(request.place());
 
 		Review review = reviewMapper.createReview(request, user, place);
@@ -274,14 +275,13 @@ public class ReviewService {
 	}
 
 	private ReviewCreateResult getCreateResult(Place place, User user) {
-		//해당 장소 리뷰 개수
 		long totalReviewCountOfPlace = reviewRepository.countByPlace_PlaceId(place.getPlaceId());
 
-		//해당 장소에서 유저가 쓴 리뷰가 몇번째인지
 		long count = reviewRepository.countByPlaceAndUser(place, user);
 		boolean isFirstReviewOfPlace = totalReviewCountOfPlace == 1;
+		int NumberOfStamp = stampRepository.countByUser(user);
 
-		return reviewMapper.toReviewCreateResult(isFirstReviewOfPlace, count);
+		return reviewMapper.toReviewCreateResult(isFirstReviewOfPlace, count, NumberOfStamp);
 
 	}
 

--- a/src/main/java/com/campus/campus/domain/review/application/service/ReviewService.java
+++ b/src/main/java/com/campus/campus/domain/review/application/service/ReviewService.java
@@ -35,6 +35,7 @@ import com.campus.campus.domain.review.domain.repository.ReviewRepository;
 import com.campus.campus.domain.school.domain.entity.College;
 import com.campus.campus.domain.school.domain.entity.Major;
 import com.campus.campus.domain.school.domain.entity.School;
+import com.campus.campus.domain.stamp.application.service.StampService;
 import com.campus.campus.domain.stamp.domain.repository.StampRepository;
 import com.campus.campus.domain.user.application.exception.UserNotFoundException;
 import com.campus.campus.domain.user.domain.entity.User;
@@ -56,6 +57,7 @@ public class ReviewService {
 	private final ReviewImageRepository reviewImageRepository;
 	private final PresignedUrlService presignedUrlService;
 	private final StudentCouncilPostRepository studentCouncilPostRepository;
+	private final StampService stampService;
 	private final StampRepository stampRepository;
 
 	@Transactional
@@ -76,6 +78,13 @@ public class ReviewService {
 			for (String imageUrl : request.imageUrls()) {
 				reviewImageRepository.save(reviewMapper.createReviewImage(review, imageUrl));
 			}
+		}
+
+		// isOcrVerificationSuccess는 ocr이 성공했다고 가정하고 구현했습니다. 이는 ocr을 구현하면서 수정해주시면 됩니다.
+		boolean isOcrVerificationSuccess = true;
+		if (isOcrVerificationSuccess) {
+			review.verify();
+			stampService.grantStampForReview(user, review);
 		}
 
 		String imageUrl =

--- a/src/main/java/com/campus/campus/domain/review/domain/entity/Review.java
+++ b/src/main/java/com/campus/campus/domain/review/domain/entity/Review.java
@@ -47,11 +47,12 @@ public class Review extends BaseEntity {
 	@JoinColumn(name = "place_id", nullable = false)
 	private Place place;
 
-	public void update(
-		String content,
-		Double star
-	) {
+	public void update(String content, Double star) {
 		this.content = content;
 		this.star = star;
+	}
+
+	public void verify() {
+		this.isVerified = true;
 	}
 }

--- a/src/main/java/com/campus/campus/domain/stamp/application/dto/response/RewardResponse.java
+++ b/src/main/java/com/campus/campus/domain/stamp/application/dto/response/RewardResponse.java
@@ -1,0 +1,17 @@
+package com.campus.campus.domain.stamp.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record RewardResponse(
+	@Schema(description = "보상 id", example = "1")
+	Long rewardId,
+
+	@Schema(description = "보상 이미지 url", example = "https://www.example.com.png")
+	String rewardImageUrl,
+
+	@Schema(description = "지급일")
+	LocalDateTime rewardDate
+) {
+}

--- a/src/main/java/com/campus/campus/domain/stamp/application/dto/response/StampInfoResponse.java
+++ b/src/main/java/com/campus/campus/domain/stamp/application/dto/response/StampInfoResponse.java
@@ -1,0 +1,14 @@
+package com.campus.campus.domain.stamp.application.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record StampInfoResponse(
+	@Schema(description = "스탬프 개수", example = "3")
+	int stampCount,
+
+	@Schema(description = "스탬프에 해당하는 리뷰 목록")
+	List<StampReviewResponse> reviews
+) {
+}

--- a/src/main/java/com/campus/campus/domain/stamp/application/dto/response/StampReviewResponse.java
+++ b/src/main/java/com/campus/campus/domain/stamp/application/dto/response/StampReviewResponse.java
@@ -1,0 +1,17 @@
+package com.campus.campus.domain.stamp.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record StampReviewResponse(
+	@Schema(description = "리뷰 id", example = "1")
+	Long reviewId,
+
+	@Schema(description = "리뷰 장소 이름", example = "투썸 플레이스")
+	String placeName,
+
+	@Schema(description = "리뷰 작성 시간", example = "2024-01-10T18:00:00")
+	LocalDateTime reviewCreatedAt
+) {
+}

--- a/src/main/java/com/campus/campus/domain/stamp/application/mapper/StampMapper.java
+++ b/src/main/java/com/campus/campus/domain/stamp/application/mapper/StampMapper.java
@@ -3,6 +3,8 @@ package com.campus.campus.domain.stamp.application.mapper;
 import org.springframework.stereotype.Component;
 
 import com.campus.campus.domain.review.domain.entity.Review;
+import com.campus.campus.domain.stamp.application.dto.response.RewardResponse;
+import com.campus.campus.domain.stamp.domain.entity.Reward;
 import com.campus.campus.domain.stamp.domain.entity.Stamp;
 import com.campus.campus.domain.user.domain.entity.User;
 
@@ -11,6 +13,14 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class StampMapper {
+	public RewardResponse toRewardResponse(Reward reward) {
+		return new RewardResponse(
+			reward.getRewardId(),
+			reward.getRewardImageUrl(),
+			reward.getCreatedAt()
+		);
+	}
+
 	public Stamp createStamp(User user, Review review) {
 		return Stamp.builder()
 			.user(user)

--- a/src/main/java/com/campus/campus/domain/stamp/application/mapper/StampMapper.java
+++ b/src/main/java/com/campus/campus/domain/stamp/application/mapper/StampMapper.java
@@ -1,0 +1,20 @@
+package com.campus.campus.domain.stamp.application.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.campus.campus.domain.review.domain.entity.Review;
+import com.campus.campus.domain.stamp.domain.entity.Stamp;
+import com.campus.campus.domain.user.domain.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class StampMapper {
+	public Stamp createStamp(User user, Review review) {
+		return Stamp.builder()
+			.user(user)
+			.review(review)
+			.build();
+	}
+}

--- a/src/main/java/com/campus/campus/domain/stamp/application/mapper/StampMapper.java
+++ b/src/main/java/com/campus/campus/domain/stamp/application/mapper/StampMapper.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 
 import com.campus.campus.domain.review.domain.entity.Review;
 import com.campus.campus.domain.stamp.application.dto.response.RewardResponse;
+import com.campus.campus.domain.stamp.application.dto.response.StampReviewResponse;
 import com.campus.campus.domain.stamp.domain.entity.Reward;
 import com.campus.campus.domain.stamp.domain.entity.Stamp;
 import com.campus.campus.domain.user.domain.entity.User;
@@ -18,6 +19,16 @@ public class StampMapper {
 			reward.getRewardId(),
 			reward.getRewardImageUrl(),
 			reward.getCreatedAt()
+		);
+	}
+
+	public StampReviewResponse toStampReviewResponse(Stamp stamp) {
+		Review review = stamp.getReview();
+
+		return new StampReviewResponse(
+			review.getId(),
+			review.getPlace().getPlaceName(),
+			review.getCreatedAt()
 		);
 	}
 

--- a/src/main/java/com/campus/campus/domain/stamp/application/service/StampService.java
+++ b/src/main/java/com/campus/campus/domain/stamp/application/service/StampService.java
@@ -7,6 +7,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.campus.campus.domain.review.domain.entity.Review;
 import com.campus.campus.domain.stamp.application.dto.response.RewardResponse;
+import com.campus.campus.domain.stamp.application.dto.response.StampInfoResponse;
+import com.campus.campus.domain.stamp.application.dto.response.StampReviewResponse;
 import com.campus.campus.domain.stamp.application.mapper.StampMapper;
 import com.campus.campus.domain.stamp.domain.entity.Stamp;
 import com.campus.campus.domain.stamp.domain.repository.RewardRepository;
@@ -39,6 +41,20 @@ public class StampService {
 		if (currentStampCount >= 10 && !user.isRewardNeeded()) {
 			user.updateRewardNeeded(true);
 		}
+	}
+
+	public StampInfoResponse getStampInfo(Long userId) {
+		User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+			.orElseThrow(UserNotFoundException::new);
+
+		int stampCount = stampRepository.countByUser(user);
+
+		List<StampReviewResponse> reviews = stampRepository.findAllByUserWithReviewAndPlace(user)
+			.stream()
+			.map(stampMapper::toStampReviewResponse)
+			.toList();
+
+		return new StampInfoResponse(stampCount, reviews);
 	}
 
 	public List<RewardResponse> findRewards(Long userId) {

--- a/src/main/java/com/campus/campus/domain/stamp/application/service/StampService.java
+++ b/src/main/java/com/campus/campus/domain/stamp/application/service/StampService.java
@@ -38,7 +38,7 @@ public class StampService {
 		stampRepository.save(stamp);
 
 		int currentStampCount = stampRepository.countByUser(user);
-		if (currentStampCount >= 10 && !user.isRewardNeeded()) {
+		if (currentStampCount % 10 == 0 && currentStampCount!=0 && !user.isRewardNeeded()) {
 			user.updateRewardNeeded(true);
 		}
 	}

--- a/src/main/java/com/campus/campus/domain/stamp/application/service/StampService.java
+++ b/src/main/java/com/campus/campus/domain/stamp/application/service/StampService.java
@@ -28,7 +28,7 @@ public class StampService {
 
 		int currentStampCount = stampRepository.countByUser(user);
 		if (currentStampCount >= 10 && !user.isRewardNeeded()) {
-			user.updateIsRewardNeeded(true);
+			user.updateRewardNeeded(true);
 		}
 	}
 }

--- a/src/main/java/com/campus/campus/domain/stamp/application/service/StampService.java
+++ b/src/main/java/com/campus/campus/domain/stamp/application/service/StampService.java
@@ -25,5 +25,10 @@ public class StampService {
 
 		Stamp stamp = stampMapper.createStamp(user, review);
 		stampRepository.save(stamp);
+
+		int currentStampCount = stampRepository.countByUser(user);
+		if (currentStampCount >= 10 && !user.isRewardNeeded()) {
+			user.updateIsRewardNeeded(true);
+		}
 	}
 }

--- a/src/main/java/com/campus/campus/domain/stamp/application/service/StampService.java
+++ b/src/main/java/com/campus/campus/domain/stamp/application/service/StampService.java
@@ -1,0 +1,29 @@
+package com.campus.campus.domain.stamp.application.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.campus.campus.domain.review.domain.entity.Review;
+import com.campus.campus.domain.stamp.application.mapper.StampMapper;
+import com.campus.campus.domain.stamp.domain.entity.Stamp;
+import com.campus.campus.domain.stamp.domain.repository.StampRepository;
+import com.campus.campus.domain.user.domain.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class StampService {
+	private final StampRepository stampRepository;
+	private final StampMapper stampMapper;
+
+	@Transactional
+	public void grantStampForReview(User user, Review review) {
+		if (stampRepository.existsByReview(review)) {
+			return;
+		}
+
+		Stamp stamp = stampMapper.createStamp(user, review);
+		stampRepository.save(stamp);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/stamp/application/service/StampService.java
+++ b/src/main/java/com/campus/campus/domain/stamp/application/service/StampService.java
@@ -1,20 +1,29 @@
 package com.campus.campus.domain.stamp.application.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.campus.campus.domain.review.domain.entity.Review;
+import com.campus.campus.domain.stamp.application.dto.response.RewardResponse;
 import com.campus.campus.domain.stamp.application.mapper.StampMapper;
 import com.campus.campus.domain.stamp.domain.entity.Stamp;
+import com.campus.campus.domain.stamp.domain.repository.RewardRepository;
 import com.campus.campus.domain.stamp.domain.repository.StampRepository;
+import com.campus.campus.domain.user.application.exception.UserNotFoundException;
 import com.campus.campus.domain.user.domain.entity.User;
+import com.campus.campus.domain.user.domain.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class StampService {
 	private final StampRepository stampRepository;
+	private final RewardRepository rewardRepository;
+	private final UserRepository userRepository;
 	private final StampMapper stampMapper;
 
 	@Transactional
@@ -30,5 +39,15 @@ public class StampService {
 		if (currentStampCount >= 10 && !user.isRewardNeeded()) {
 			user.updateRewardNeeded(true);
 		}
+	}
+
+	public List<RewardResponse> findRewards(Long userId) {
+		User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+			.orElseThrow(UserNotFoundException::new);
+
+		return rewardRepository.findAllByUserOrderByRewardIdDesc(user)
+			.stream()
+			.map(stampMapper::toRewardResponse)
+			.toList();
 	}
 }

--- a/src/main/java/com/campus/campus/domain/stamp/domain/entity/Reward.java
+++ b/src/main/java/com/campus/campus/domain/stamp/domain/entity/Reward.java
@@ -1,0 +1,39 @@
+package com.campus.campus.domain.stamp.domain.entity;
+
+import com.campus.campus.domain.user.domain.entity.User;
+import com.campus.campus.global.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "rewards")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Reward extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "reward_id")
+	private Long rewardId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Column(name = "reward_image_url")
+	private String rewardImageUrl;
+}

--- a/src/main/java/com/campus/campus/domain/stamp/domain/entity/Stamp.java
+++ b/src/main/java/com/campus/campus/domain/stamp/domain/entity/Stamp.java
@@ -1,0 +1,42 @@
+package com.campus.campus.domain.stamp.domain.entity;
+
+import com.campus.campus.domain.review.domain.entity.Review;
+import com.campus.campus.domain.user.domain.entity.User;
+import com.campus.campus.global.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "stamps")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Stamp extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "stamp_id")
+	private Long stampId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "review_id", nullable = false)
+	private Review review;
+}

--- a/src/main/java/com/campus/campus/domain/stamp/domain/repository/RewardRepository.java
+++ b/src/main/java/com/campus/campus/domain/stamp/domain/repository/RewardRepository.java
@@ -1,0 +1,8 @@
+package com.campus.campus.domain.stamp.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.campus.campus.domain.stamp.domain.entity.Reward;
+
+public interface RewardRepository extends JpaRepository<Reward, Long> {
+}

--- a/src/main/java/com/campus/campus/domain/stamp/domain/repository/RewardRepository.java
+++ b/src/main/java/com/campus/campus/domain/stamp/domain/repository/RewardRepository.java
@@ -1,8 +1,12 @@
 package com.campus.campus.domain.stamp.domain.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.campus.campus.domain.stamp.domain.entity.Reward;
+import com.campus.campus.domain.user.domain.entity.User;
 
 public interface RewardRepository extends JpaRepository<Reward, Long> {
+	List<Reward> findAllByUserOrderByRewardIdDesc(User user);
 }

--- a/src/main/java/com/campus/campus/domain/stamp/domain/repository/StampRepository.java
+++ b/src/main/java/com/campus/campus/domain/stamp/domain/repository/StampRepository.java
@@ -1,0 +1,8 @@
+package com.campus.campus.domain.stamp.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.campus.campus.domain.stamp.domain.entity.Stamp;
+
+public interface StampRepository extends JpaRepository<Stamp, Long> {
+}

--- a/src/main/java/com/campus/campus/domain/stamp/domain/repository/StampRepository.java
+++ b/src/main/java/com/campus/campus/domain/stamp/domain/repository/StampRepository.java
@@ -1,6 +1,10 @@
 package com.campus.campus.domain.stamp.domain.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.campus.campus.domain.review.domain.entity.Review;
 import com.campus.campus.domain.stamp.domain.entity.Stamp;
@@ -10,4 +14,14 @@ public interface StampRepository extends JpaRepository<Stamp, Long> {
 	boolean existsByReview(Review review);
 
 	int countByUser(User user);
+
+	@Query("""
+		SELECT s
+		FROM Stamp s
+		JOIN FETCH s.review r
+		JOIN FETCH r.place
+		WHERE s.user = :user
+		ORDER BY s.createdAt DESC
+		""")
+	List<Stamp> findAllByUserWithReviewAndPlace(@Param("user") User user);
 }

--- a/src/main/java/com/campus/campus/domain/stamp/domain/repository/StampRepository.java
+++ b/src/main/java/com/campus/campus/domain/stamp/domain/repository/StampRepository.java
@@ -2,7 +2,12 @@ package com.campus.campus.domain.stamp.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.campus.campus.domain.review.domain.entity.Review;
 import com.campus.campus.domain.stamp.domain.entity.Stamp;
+import com.campus.campus.domain.user.domain.entity.User;
 
 public interface StampRepository extends JpaRepository<Stamp, Long> {
+	boolean existsByReview(Review review);
+
+	int countByUser(User user);
 }

--- a/src/main/java/com/campus/campus/domain/stamp/presentation/StampController.java
+++ b/src/main/java/com/campus/campus/domain/stamp/presentation/StampController.java
@@ -1,0 +1,30 @@
+package com.campus.campus.domain.stamp.presentation;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.campus.campus.domain.stamp.application.dto.response.RewardResponse;
+import com.campus.campus.domain.stamp.application.service.StampService;
+import com.campus.campus.global.annotation.CurrentUserId;
+import com.campus.campus.global.common.response.CommonResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/stamps")
+@RequiredArgsConstructor
+public class StampController {
+	private final StampService stampService;
+
+	@GetMapping("/rewards")
+	@Operation(summary = "스탬프 보상 목록 조회 기능")
+	public CommonResponse<List<RewardResponse>> getRewards(@CurrentUserId Long userId) {
+		List<RewardResponse> rewardResponse = stampService.findRewards(userId);
+
+		return CommonResponse.success(StampResponseCode.REWARD_LIST_SUCCESS, rewardResponse);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/stamp/presentation/StampController.java
+++ b/src/main/java/com/campus/campus/domain/stamp/presentation/StampController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.campus.campus.domain.stamp.application.dto.response.RewardResponse;
+import com.campus.campus.domain.stamp.application.dto.response.StampInfoResponse;
 import com.campus.campus.domain.stamp.application.service.StampService;
 import com.campus.campus.global.annotation.CurrentUserId;
 import com.campus.campus.global.common.response.CommonResponse;
@@ -19,6 +20,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class StampController {
 	private final StampService stampService;
+
+	@GetMapping
+	@Operation(summary = "스탬프 개수 및 리뷰 목록 조회")
+	public CommonResponse<StampInfoResponse> getStampInfo(@CurrentUserId Long userId) {
+		StampInfoResponse stampInfoResponse = stampService.getStampInfo(userId);
+
+		return CommonResponse.success(StampResponseCode.STAMP_INFO_SUCCESS, stampInfoResponse);
+	}
 
 	@GetMapping("/rewards")
 	@Operation(summary = "스탬프 보상 목록 조회 기능")

--- a/src/main/java/com/campus/campus/domain/stamp/presentation/StampResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/stamp/presentation/StampResponseCode.java
@@ -10,7 +10,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum StampResponseCode implements ResponseCodeInterface {
-	REWARD_LIST_SUCCESS(200, HttpStatus.OK, "스탬프 보상 목록 조회에 성공했습니다.");
+	REWARD_LIST_SUCCESS(200, HttpStatus.OK, "스탬프 보상 목록 조회에 성공했습니다."),
+	STAMP_INFO_SUCCESS(200, HttpStatus.OK, "스탬프 정보 조회에 성공했습니다.");
 
 	private final int code;
 	private final HttpStatus status;

--- a/src/main/java/com/campus/campus/domain/stamp/presentation/StampResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/stamp/presentation/StampResponseCode.java
@@ -1,0 +1,18 @@
+package com.campus.campus.domain.stamp.presentation;
+
+import org.springframework.http.HttpStatus;
+
+import com.campus.campus.global.common.response.ResponseCodeInterface;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum StampResponseCode implements ResponseCodeInterface {
+	REWARD_LIST_SUCCESS(200, HttpStatus.OK, "스탬프 보상 목록 조회에 성공했습니다.");
+
+	private final int code;
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/com/campus/campus/domain/user/domain/entity/User.java
+++ b/src/main/java/com/campus/campus/domain/user/domain/entity/User.java
@@ -18,6 +18,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -48,6 +49,10 @@ public class User extends BaseEntity {
 
 	@Column(name = "campus_nickname")
 	private String campusNickname;
+
+	@Column(name = "is_reward_needed")
+	@Builder.Default
+	private boolean isRewardNeeded = false;
 
 	@Column(name = "deleted_at")
 	private LocalDateTime deletedAt;
@@ -80,5 +85,9 @@ public class User extends BaseEntity {
 
 	public boolean isProfileNotCompleted() {
 		return this.school == null || this.major == null;
+	}
+
+	public void updateIsRewardNeeded(boolean isRewardNeeded) {
+		this.isRewardNeeded = isRewardNeeded;
 	}
 }

--- a/src/main/java/com/campus/campus/domain/user/domain/entity/User.java
+++ b/src/main/java/com/campus/campus/domain/user/domain/entity/User.java
@@ -50,9 +50,9 @@ public class User extends BaseEntity {
 	@Column(name = "campus_nickname")
 	private String campusNickname;
 
-	@Column(name = "is_reward_needed")
+	@Column(name = "reward_needed")
 	@Builder.Default
-	private boolean isRewardNeeded = false;
+	private boolean RewardNeeded = false;
 
 	@Column(name = "deleted_at")
 	private LocalDateTime deletedAt;
@@ -87,7 +87,7 @@ public class User extends BaseEntity {
 		return this.school == null || this.major == null;
 	}
 
-	public void updateIsRewardNeeded(boolean isRewardNeeded) {
-		this.isRewardNeeded = isRewardNeeded;
+	public void updateRewardNeeded(boolean RewardNeeded) {
+		this.RewardNeeded = RewardNeeded;
 	}
 }

--- a/src/main/java/com/campus/campus/domain/user/domain/entity/User.java
+++ b/src/main/java/com/campus/campus/domain/user/domain/entity/User.java
@@ -52,7 +52,7 @@ public class User extends BaseEntity {
 
 	@Column(name = "reward_needed")
 	@Builder.Default
-	private boolean RewardNeeded = false;
+	private boolean rewardNeeded = false;
 
 	@Column(name = "deleted_at")
 	private LocalDateTime deletedAt;
@@ -87,7 +87,7 @@ public class User extends BaseEntity {
 		return this.school == null || this.major == null;
 	}
 
-	public void updateRewardNeeded(boolean RewardNeeded) {
-		this.RewardNeeded = RewardNeeded;
+	public void updateRewardNeeded(boolean rewardNeeded) {
+		this.rewardNeeded = rewardNeeded;
 	}
 }

--- a/src/main/java/com/campus/campus/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/campus/campus/domain/user/domain/repository/UserRepository.java
@@ -33,8 +33,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
        """)
 	Optional<User> findByIdWithAcademicInfo(@Param("userId") Long userId);
 
-	List<User> findAllByRewardNeededIsTrueAndDeletedAtIsNull();
-
 	@Query("""
 		SELECT u, COUNT(s)
 		FROM User u

--- a/src/main/java/com/campus/campus/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/campus/campus/domain/user/domain/repository/UserRepository.java
@@ -32,4 +32,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
        AND u.deletedAt IS NULL
        """)
 	Optional<User> findByIdWithAcademicInfo(@Param("userId") Long userId);
+
+	List<User> findAllByRewardNeededIsTrueAndDeletedAtIsNull();
 }

--- a/src/main/java/com/campus/campus/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/campus/campus/domain/user/domain/repository/UserRepository.java
@@ -34,4 +34,14 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByIdWithAcademicInfo(@Param("userId") Long userId);
 
 	List<User> findAllByRewardNeededIsTrueAndDeletedAtIsNull();
+
+	@Query("""
+		SELECT u, COUNT(s)
+		FROM User u
+		LEFT JOIN Stamp s ON s.user = u
+		WHERE u.rewardNeeded = true 
+		  AND u.deletedAt IS NULL
+		GROUP BY u
+		""")
+	List<Object[]> findRewardNeededUsersWithStampCount();
 }


### PR DESCRIPTION
## 🔀 변경 내용
- 스탬프 기능을 구현했습니다.

## ✅ 작업 항목
- [x] 리뷰 생성 시 스탬프를 같이 부여할 수 있도록 기능을 구현했습니다. (Stamp 테이블 추가)
현재는 ocr 기능이 구현되어있지 않기에 현재 ocr 인증이 성공했다는 가정하에 진행했습니다.
또한 리뷰 생성 시 반환값에 해당 유저의 스탬프 수를 추가했습니다.
- [x] User 엔티티에 rewardNeeded 컬럼을 추가하였으며 스탬프 10개 획득 시 해당 컬럼이 true로 바뀌도록 구현했습니다. 
- [x] 관리자는 rewardNeeded가 true인, 보상 지급이 필요한 유저들을 조회하는 기능을 구현했습니다.
- [x] 관리자가 사용자에게 보상을 지급하는 기능을 구현했습니다. (Reward 테이블 추가) 보상 지급 시 해당 유저의 rewardNeeded는 다시 false로 전환.
- [x] 사용자의 스탬프 개수 및 스탬프 받은 리뷰들을 조회하는 기능을 구현했습니다.
- [x] 사용자의 스탬프 보상을 조회하는 기능을 구현했습니다.

## 📸 스크린샷 (선택)
### 리뷰 생성 시 stamp도 생성되며 반환값에 현재 사용자의 스탬프 개수 반환
<img width="1468" height="587" alt="image" src="https://github.com/user-attachments/assets/3e33f9b1-2ba8-42d1-8764-94bcf9ff0617" />

### 관리자의 보상 지급이 필요한 유저 조회 기능
<img width="1461" height="388" alt="image" src="https://github.com/user-attachments/assets/627dd833-15f8-4eca-ad9b-3b120e76dd0d" />

### 관리자의 보상 지급 기능
<img width="1478" height="935" alt="image" src="https://github.com/user-attachments/assets/0d97568d-ac76-4f21-a4ef-2c5a1facd51f" />

### 사용자의 스탬프 개수 및 스탬프 받은 리뷰 조회 기능
<img width="1469" height="581" alt="image" src="https://github.com/user-attachments/assets/93980c87-91be-49e9-afa4-c1ea50dc190a" />

### 사용자의 스탬프 보상 조회 기능
<img width="1470" height="870" alt="image" src="https://github.com/user-attachments/assets/79c9b406-7566-441a-a199-134c9e578fd9" />

## 📎 참고 이슈
관련 이슈 번호 #63 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 스탬프·보상 시스템 도입: 리뷰 작성 시 스탬프 지급, 스탬프 10개 이상이면 보상 대상 표시
  * 개인용 스탬프 정보 조회(API): 스탬프 개수 및 관련 리뷰 목록 확인
  * 개인용 보상 내역 조회(API): 받은 보상 목록 확인(이미지·지급일 포함)
  * 관리자용 API: 보상이 필요한 사용자 목록 조회 및 개별 보상 지급(보상 이미지 업로드)
  * 리뷰 검증 시 스탬프 자동 부여 및 보상 흐름 연동

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->