### PR TITLE
Feat/#65 학생회 닉네임 설정 기능 구현(학생회 마이페이지)

### DIFF
--- a/src/main/java/com/campus/campus/domain/council/application/dto/request/StudentCouncilNicknameRequest.java
+++ b/src/main/java/com/campus/campus/domain/council/application/dto/request/StudentCouncilNicknameRequest.java
@@ -1,0 +1,11 @@
+package com.campus.campus.domain.council.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record StudentCouncilNicknameRequest(
+	@Schema(description = "학생회 닉네임", example = "CUBE")
+	@NotBlank
+	String councilNickname
+) {
+}

--- a/src/main/java/com/campus/campus/domain/council/application/dto/response/StudentCouncilLoginResponse.java
+++ b/src/main/java/com/campus/campus/domain/council/application/dto/response/StudentCouncilLoginResponse.java
@@ -35,6 +35,9 @@ public record StudentCouncilLoginResponse(
 	String majorName,
 
 	@Schema(description = "학생회 이름", example = "가천대학교 총학생회")
-	String councilName
+	String councilName,
+
+	@Schema(description = "학생회 닉네임", example = "CUBE")
+	String councilNickname
 ) {
 }

--- a/src/main/java/com/campus/campus/domain/council/application/dto/response/StudentCouncilNicknameResponse.java
+++ b/src/main/java/com/campus/campus/domain/council/application/dto/response/StudentCouncilNicknameResponse.java
@@ -1,0 +1,12 @@
+package com.campus.campus.domain.council.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record StudentCouncilNicknameResponse(
+	@Schema(description = "학생회 닉네임", example = "CUBE")
+	String councilNickname,
+
+	@Schema(description = "학생회 이름", example = "가천대학교 총학생회")
+	String councilName
+) {
+}

--- a/src/main/java/com/campus/campus/domain/council/application/mapper/StudentCouncilMapper.java
+++ b/src/main/java/com/campus/campus/domain/council/application/mapper/StudentCouncilMapper.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilSignUpRequest;
 import com.campus.campus.domain.council.application.dto.response.StudentCouncilFindIdResponse;
 import com.campus.campus.domain.council.application.dto.response.StudentCouncilLoginResponse;
+import com.campus.campus.domain.council.application.dto.response.StudentCouncilNicknameResponse;
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.school.domain.entity.College;
 import com.campus.campus.domain.school.domain.entity.Major;
@@ -15,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class StudentCouncilLoginMapper {
+public class StudentCouncilMapper {
 	private final SecurityConfig securityConfig;
 
 	public StudentCouncil createStudentCouncil(StudentCouncilSignUpRequest studentCouncilSignUpRequest, School school,
@@ -54,6 +55,13 @@ public class StudentCouncilLoginMapper {
 	public StudentCouncilFindIdResponse toStudentCouncilFindIdResponse(String loginId) {
 		return new StudentCouncilFindIdResponse(
 			loginId
+		);
+	}
+
+	public StudentCouncilNicknameResponse toStudentCouncilNicknameResponse(StudentCouncil studentCouncil) {
+		return new StudentCouncilNicknameResponse(
+			studentCouncil.getCouncilNickname(),
+			studentCouncil.getCouncilName()
 		);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/council/application/mapper/StudentCouncilMapper.java
+++ b/src/main/java/com/campus/campus/domain/council/application/mapper/StudentCouncilMapper.java
@@ -48,7 +48,8 @@ public class StudentCouncilMapper {
 			studentCouncil.getSchool().getSchoolName(),
 			studentCouncil.getCollege() != null ? studentCouncil.getCollege().getCollegeName() : null,
 			studentCouncil.getMajor() != null ? studentCouncil.getMajor().getMajorName() : null,
-			studentCouncil.getCouncilName()
+			studentCouncil.getCouncilName(),
+			studentCouncil.getCouncilNickname()
 		);
 	}
 

--- a/src/main/java/com/campus/campus/domain/council/application/service/CouncilLoginService.java
+++ b/src/main/java/com/campus/campus/domain/council/application/service/CouncilLoginService.java
@@ -25,7 +25,7 @@ import com.campus.campus.domain.council.application.exception.PasswordNotCorrect
 import com.campus.campus.domain.council.application.exception.PrecautionNotAgreeException;
 import com.campus.campus.domain.council.application.exception.SignupEmailNotFoundException;
 import com.campus.campus.domain.council.application.exception.StudentCouncilNotFoundException;
-import com.campus.campus.domain.council.application.mapper.StudentCouncilLoginMapper;
+import com.campus.campus.domain.council.application.mapper.StudentCouncilMapper;
 import com.campus.campus.domain.council.application.util.CouncilNameGenerator;
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.council.domain.repository.StudentCouncilRepository;
@@ -58,7 +58,7 @@ public class CouncilLoginService {
 	private final SchoolRepository schoolRepository;
 	private final CollegeRepository collegeRepository;
 	private final MajorRepository majorRepository;
-	private final StudentCouncilLoginMapper studentCouncilLoginMapper;
+	private final StudentCouncilMapper studentCouncilMapper;
 	private final EmailVerificationRepository emailVerificationRepository;
 	private final JwtProvider jwtProvider;
 	private final SecurityConfig securityConfig;
@@ -90,7 +90,7 @@ public class CouncilLoginService {
 
 		CouncilScope scope = validateCouncilScope(studentCouncilSignUpRequest, school);
 
-		StudentCouncil studentCouncil = studentCouncilLoginMapper.createStudentCouncil(
+		StudentCouncil studentCouncil = studentCouncilMapper.createStudentCouncil(
 			studentCouncilSignUpRequest, school, scope.college, scope.major);
 
 		String councilName = councilNameGenerator.buildCouncilName(studentCouncil);
@@ -122,7 +122,7 @@ public class CouncilLoginService {
 		redisTokenService.setRefreshToken("COUNCIL", String.valueOf(studentCouncil.getId()), refreshToken,
 			refreshTokenExpirationSeconds);
 
-		return studentCouncilLoginMapper.toStudentCouncilLoginResponse(studentCouncil, accessToken, refreshToken);
+		return studentCouncilMapper.toStudentCouncilLoginResponse(studentCouncil, accessToken, refreshToken);
 	}
 
 	@Transactional
@@ -139,7 +139,7 @@ public class CouncilLoginService {
 
 		emailVerification.use();
 
-		return studentCouncilLoginMapper.toStudentCouncilFindIdResponse(studentCouncil.getLoginId());
+		return studentCouncilMapper.toStudentCouncilFindIdResponse(studentCouncil.getLoginId());
 	}
 
 	@Transactional

--- a/src/main/java/com/campus/campus/domain/council/application/service/CouncilService.java
+++ b/src/main/java/com/campus/campus/domain/council/application/service/CouncilService.java
@@ -5,11 +5,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilChangeEmailRequest;
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilChangePasswordRequest;
+import com.campus.campus.domain.council.application.dto.request.StudentCouncilNicknameRequest;
+import com.campus.campus.domain.council.application.dto.response.StudentCouncilNicknameResponse;
 import com.campus.campus.domain.council.application.exception.EmailAlreadyExistsException;
 import com.campus.campus.domain.council.application.exception.NewPasswordConfirmNotMatchException;
 import com.campus.campus.domain.council.application.exception.NewPasswordIsCurrentPasswordException;
 import com.campus.campus.domain.council.application.exception.PasswordNotCorrectException;
 import com.campus.campus.domain.council.application.exception.StudentCouncilNotFoundException;
+import com.campus.campus.domain.council.application.mapper.StudentCouncilMapper;
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.council.domain.repository.StudentCouncilRepository;
 import com.campus.campus.domain.mail.application.exception.EmailVerificationNotFoundException;
@@ -28,6 +31,7 @@ public class CouncilService {
 	private final StudentCouncilRepository studentCouncilRepository;
 	private final EmailVerificationRepository emailVerificationRepository;
 	private final SecurityConfig securityConfig;
+	private final StudentCouncilMapper studentCouncilMapper;
 
 	@Transactional
 	public void changeEmail(Long councilId, StudentCouncilChangeEmailRequest studentCouncilChangeEmailRequest) {
@@ -74,6 +78,19 @@ public class CouncilService {
 		studentCouncil.changePassword(newPassword);
 
 		studentCouncilRepository.save(studentCouncil);
+	}
+
+	@Transactional
+	public StudentCouncilNicknameResponse changeCouncilNickname(Long councilId,
+		StudentCouncilNicknameRequest studentCouncilNicknameRequest) {
+		StudentCouncil studentCouncil = studentCouncilRepository
+			.findByIdAndManagerApprovedIsTrueAndDeletedAtIsNull(councilId)
+			.orElseThrow(StudentCouncilNotFoundException::new);
+
+		studentCouncil.updateCouncilNickname(studentCouncilNicknameRequest.councilNickname());
+		studentCouncilRepository.save(studentCouncil);
+
+		return studentCouncilMapper.toStudentCouncilNicknameResponse(studentCouncil);
 	}
 
 	private EmailVerification getVerifiedChangeEmail(Long councilId, String email) {

--- a/src/main/java/com/campus/campus/domain/council/domain/entity/StudentCouncil.java
+++ b/src/main/java/com/campus/campus/domain/council/domain/entity/StudentCouncil.java
@@ -65,6 +65,9 @@ public class StudentCouncil extends BaseEntity {
 	@Column(name = "council_name")
 	private String councilName;
 
+	@Column(name = "council_nickname")
+	private String councilNickname;
+
 	@Column(name = "election_image_url")
 	private String electionImageUrl;
 
@@ -84,6 +87,10 @@ public class StudentCouncil extends BaseEntity {
 
 	public void changeEmail(String newEmail) {
 		this.email = newEmail;
+	}
+
+	public void updateCouncilNickname(String nickname) {
+		this.councilNickname = nickname;
 	}
 
 	public void generateCouncilName(String councilName) {

--- a/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilController.java
+++ b/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilController.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilChangeEmailRequest;
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilChangePasswordRequest;
+import com.campus.campus.domain.council.application.dto.request.StudentCouncilNicknameRequest;
+import com.campus.campus.domain.council.application.dto.response.StudentCouncilNicknameResponse;
 import com.campus.campus.domain.council.application.service.CouncilService;
 import com.campus.campus.global.annotation.CurrentCouncilId;
 import com.campus.campus.global.common.response.CommonResponse;
@@ -39,5 +41,15 @@ public class StudentCouncilController {
 		councilService.changePassword(councilId, studentCouncilChangePasswordRequest);
 
 		return CommonResponse.success(StudentCouncilResponseCode.CHANGE_PASSWORD_SUCCESS);
+	}
+
+	@PatchMapping("/change/nickname")
+	@Operation(summary = "학생회 닉네임 변경")
+	public CommonResponse<StudentCouncilNicknameResponse> changeNickname(@CurrentCouncilId Long councilId,
+		@Valid @RequestBody StudentCouncilNicknameRequest studentCouncilNicknameRequest) {
+		StudentCouncilNicknameResponse response = councilService.changeCouncilNickname(councilId,
+			studentCouncilNicknameRequest);
+
+		return CommonResponse.success(StudentCouncilResponseCode.CHANGE_NICKNAME_SUCCESS, response);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilResponseCode.java
@@ -18,6 +18,7 @@ public enum StudentCouncilResponseCode implements ResponseCodeInterface {
 	FIND_PASSWORD_SUCCESS(200, HttpStatus.OK, "비밀번호 재설정에 성공했습니다."),
 	CHANGE_EMAIL_SUCCESS(200, HttpStatus.OK, "이메일 변경에 성공했습니다."),
 	CHANGE_PASSWORD_SUCCESS(200, HttpStatus.OK, "비밀번호 변경에 성공했습니다."),
+	CHANGE_NICKNAME_SUCCESS(200, HttpStatus.OK, "학생회 닉네임 변경에 성공했습니다."),
 	COUNCIL_WITHDRAW_SUCCESS(200, HttpStatus.OK, "학생회 회원탈퇴에 성공했습니다.");
 
 	private final int code;


### PR DESCRIPTION
## 🔀 변경 내용
- 학생회 이름(닉네임)을 설정(수정)하는 기능을 구현했습니다.

## ✅ 작업 항목
- [x] 학생회 이름(닉네임)을 설정(수정)하는 기능을 구현 - councilNickname 컬럼 추가
- [x] 학생회 로그인 시 반환값에 학생회 닉네임 추가

## 📸 스크린샷 (선택)
### 닉네임 설정
<img width="1120" height="322" alt="image" src="https://github.com/user-attachments/assets/c9a15b2d-6e17-4c73-9851-d4820b0ca3a0" />

### 로그인 시 학생회 닉네임도 반환
<img width="1125" height="485" alt="image" src="https://github.com/user-attachments/assets/c1728112-ad24-45f6-8c0e-20f15995a1fb" />


## 📎 참고 이슈
관련 이슈 번호 #65 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 학생회 닉네임 변경 기능 추가
  * 로그인 응답 및 학생회 정보에 닉네임 포함

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->