### PR TITLE
Refactor/#67 일반 유저 게시글 조회 시 지난 행사 및 제휴는 종료되었음이 표시되도록 수정

### DIFF
--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetPostForUserResponse.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/GetPostForUserResponse.java
@@ -32,6 +32,8 @@ public record GetPostForUserResponse(
 
 	boolean isLiked,
 
+	boolean isEnded,
+
 	List<String> images
 ) {
 }

--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/PostListItemResponse.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/response/PostListItemResponse.java
@@ -16,6 +16,7 @@ public record PostListItemResponse(
 	LocalDateTime endDateTime,
 	String thumbnailImageUrl,
 	ThumbnailIcon thumbnailIcon,
-	boolean liked
+	boolean liked,
+	boolean isEnded
 ) {
 }

--- a/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
@@ -1,6 +1,7 @@
 package com.campus.campus.domain.councilpost.application.mapper;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.List;
 
@@ -30,7 +31,11 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class StudentCouncilPostMapper {
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
 	public PostListItemResponse toPostListItemResponse(StudentCouncilPost post, boolean isLiked) {
+		LocalDateTime now = LocalDateTime.now(KST);
+
 		return new PostListItemResponse(
 			post.getId(),
 			post.getCategory(),
@@ -40,7 +45,8 @@ public class StudentCouncilPostMapper {
 			post.isEvent() ? post.getStartDateTime() : post.getEndDateTime(),
 			post.getThumbnailImageUrl(),
 			post.getThumbnailIcon(),
-			isLiked
+			isLiked,
+			post.isClosed(now)
 		);
 	}
 
@@ -133,7 +139,9 @@ public class StudentCouncilPostMapper {
 
 	public GetPostForUserResponse toGetPostForUserResponse(StudentCouncilPost post, List<String> images,
 		Long currentUserId, boolean isLiked) {
+		LocalDateTime now = LocalDateTime.now(KST);
 		var writer = post.getWriter();
+
 		var builder = GetPostForUserResponse.builder()
 			.id(post.getId())
 			.writerId(writer.getId())
@@ -146,6 +154,7 @@ public class StudentCouncilPostMapper {
 			.thumbnailImageUrl(post.getThumbnailImageUrl())
 			.thumbnailIcon(post.getThumbnailIcon())
 			.isLiked(isLiked)
+			.isEnded(post.isClosed(now))
 			.images(images != null ? images : Collections.emptyList());
 
 		if (post.isEvent()) {

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/entity/StudentCouncilPost.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/entity/StudentCouncilPost.java
@@ -105,7 +105,7 @@ public class StudentCouncilPost extends BaseEntity {
 
 	public boolean isClosed(LocalDateTime now) {
 		if (this.category == PostCategory.EVENT) {
-			return this.startDateTime != null && this.startDateTime.isBefore(now);
+			return this.startDateTime != null && now.toLocalDate().isAfter(this.startDateTime.toLocalDate());
 		} else {
 			return this.endDateTime != null && this.endDateTime.isBefore(now);
 		}

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/entity/StudentCouncilPost.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/entity/StudentCouncilPost.java
@@ -103,4 +103,11 @@ public class StudentCouncilPost extends BaseEntity {
 		return writer != null && writer.getId().equals(councilId);
 	}
 
+	public boolean isClosed(LocalDateTime now) {
+		if (this.category == PostCategory.EVENT) {
+			return this.startDateTime != null && this.startDateTime.isBefore(now);
+		} else {
+			return this.endDateTime != null && this.endDateTime.isBefore(now);
+		}
+	}
 }


### PR DESCRIPTION
## 🔀 변경 내용
- 일반 유저 게시글 조회 시 지난 행사 및 제휴는 종료되었음이 표시되도록 수정했습니다.

## ✅ 작업 항목
- [x] 학교/단과대/학과 학생회 게시글 목록 조회 시 각 게시물이 행사/제휴가 종료되었는지 표시되도록 수정했습니다.
- [x] 게시글 상세 조회 시 게시물이 행사/제휴가 종료되었는지 표시되도록 수정했습니다.

## 📸 스크린샷 (선택)
### 목록 조회 (응답값에 isClosed 추가)
<img width="1128" height="570" alt="image" src="https://github.com/user-attachments/assets/06167ecc-223f-4810-9850-86ba60f3560f" />

### 상세 조회 (응답값에 isClosed 추가)
<img width="1123" height="486" alt="image" src="https://github.com/user-attachments/assets/b9c9a093-7cfa-48ad-a6cf-05f383712573" />


## 📎 참고 이슈
관련 이슈 번호 #67 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 게시글 종료 상태 표시 추가 - 게시글 목록과 상세 정보 페이지에서 각 게시글의 종료 여부를 확인할 수 있습니다. 행사는 시작일 이후, 일반 게시글은 종료일 이후 자동으로 종료 상태로 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->