### PR TITLE
Refactor/#73 관리자가 유저에게 보상 지급 시 유저에게 알림이 가도록 구현

### DIFF
--- a/src/main/java/com/campus/campus/domain/manager/application/dto/request/RewardGrantedEvent.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/dto/request/RewardGrantedEvent.java
@@ -1,0 +1,10 @@
+package com.campus.campus.domain.manager.application.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record RewardGrantedEvent(
+	Long userId,
+	String rewardName
+) {
+}

--- a/src/main/java/com/campus/campus/domain/manager/application/mapper/ManagerMapper.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/mapper/ManagerMapper.java
@@ -3,6 +3,7 @@ package com.campus.campus.domain.manager.application.mapper;
 import org.springframework.stereotype.Component;
 
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
+import com.campus.campus.domain.manager.application.dto.request.RewardGrantedEvent;
 import com.campus.campus.domain.manager.application.dto.request.RewardRequest;
 import com.campus.campus.domain.manager.application.dto.response.CertifyRequestCouncilResponse;
 import com.campus.campus.domain.manager.application.dto.response.CouncilApproveOrDenyResponse;
@@ -67,6 +68,13 @@ public class ManagerMapper {
 		return Reward.builder()
 			.user(user)
 			.rewardImageUrl(rewardRequest.rewardImageUrl())
+			.build();
+	}
+
+	public RewardGrantedEvent createRewardGrantedEvent(Long userId, String rewardName) {
+		return RewardGrantedEvent.builder()
+			.userId(userId)
+			.rewardName(rewardName)
 			.build();
 	}
 }

--- a/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
@@ -3,6 +3,7 @@ package com.campus.campus.domain.manager.application.service;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -48,6 +49,7 @@ public class ManagerService {
 	private final RedisTokenService redisTokenService;
 	private final ManagerMapper managerMapper;
 	private final JavaMailSender javaMailSender;
+	private final ApplicationEventPublisher eventPublisher;
 
 	@Value("${jwt.refresh.expiration-seconds}")
 	private long refreshTokenExpirationSeconds;
@@ -128,6 +130,8 @@ public class ManagerService {
 		rewardRepository.save(reward);
 
 		user.updateRewardNeeded(false);
+
+		eventPublisher.publishEvent(managerMapper.createRewardGrantedEvent(userId, "스탬프 보상"));
 	}
 
 	private void sendCouncilApprovedMail(String to) {

--- a/src/main/java/com/campus/campus/domain/manager/application/service/RewardPushListener.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/service/RewardPushListener.java
@@ -1,0 +1,48 @@
+package com.campus.campus.domain.manager.application.service;
+
+import java.util.Map;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.campus.campus.domain.manager.application.dto.request.RewardGrantedEvent;
+import com.campus.campus.domain.notification.application.service.NotificationService;
+import com.campus.campus.global.firebase.application.service.FirebaseCloudMessageService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RewardPushListener {
+	private static final String DATA_KEY_TYPE = "type";
+	private static final String DATA_TYPE_REWARD_GRANTED = "REWARD_GRANTED";
+
+	private final FirebaseCloudMessageService firebaseCloudMessageService;
+	private final NotificationService notificationService;
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleRewardGrantedEvent(RewardGrantedEvent rewardGrantedEvent) {
+		String title = "보상 지급 알림";
+		String body = "스탬프 보상이 지급되었습니다. 보상함을 확인해주세요.";
+
+		notificationService.saveRewardGrantedNotification(rewardGrantedEvent.userId(), title, body);
+
+		String userTopic = "user_" + rewardGrantedEvent.userId();
+
+		log.info("[PUSH] Reward granted. topic={}, userId={}", userTopic, rewardGrantedEvent.userId());
+
+		firebaseCloudMessageService.sendToTopic(
+			userTopic,
+			title,
+			body,
+			Map.of(
+				DATA_KEY_TYPE, DATA_TYPE_REWARD_GRANTED
+			)
+		);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/notification/application/service/NotificationService.java
+++ b/src/main/java/com/campus/campus/domain/notification/application/service/NotificationService.java
@@ -101,6 +101,17 @@ public class NotificationService {
 		notificationRepository.saveAll(notifications);
 	}
 
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void saveRewardGrantedNotification(Long userId, String title, String body) {
+		User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+			.orElseThrow(UserNotFoundException::new);
+
+		Notification notification = notificationMapper.createNotification(user, NotificationType.REWARD_GRANTED, title,
+			body, null);
+
+		notificationRepository.save(notification);
+	}
+
 	@Transactional(readOnly = true)
 	public boolean hasUnread(Long userId) {
 		return notificationRepository.existsByUser_IdAndIsReadFalse(userId);

--- a/src/main/java/com/campus/campus/domain/notification/domain/entity/NotificationType.java
+++ b/src/main/java/com/campus/campus/domain/notification/domain/entity/NotificationType.java
@@ -2,5 +2,6 @@ package com.campus.campus.domain.notification.domain.entity;
 
 public enum NotificationType {
 	COUNCIL_POST_CREATED,
-	SYSTEM_NOTICE
+	SYSTEM_NOTICE,
+	REWARD_GRANTED
 }


### PR DESCRIPTION
## 🔀 변경 내용
- 관리자가 유저에게 보상 지급 시 유저에게 알림이 가도록 구현했습니다.

## ✅ 작업 항목
- [x] 관리자가 보상 지급 시 유저에게 알림 전송 기능 구현
- [x] 알림 전송 시 해당 알림 DB에 저장되도록 구현

## 📸 스크린샷 (선택)
### 보상 지급 시 알림 전송
<img width="1453" height="282" alt="image" src="https://github.com/user-attachments/assets/ac4510b1-625c-41c8-b3ea-44a1b8753df9" />
<img width="1634" height="128" alt="image" src="https://github.com/user-attachments/assets/4896e5dc-ff23-4237-8ace-34388720614e" />


### 알림함에 보상 지급 알림 저장
<img width="1402" height="539" alt="image" src="https://github.com/user-attachments/assets/8a9540ed-dd6e-46ae-9340-15bc0a1ca2cf" />

## 📎 참고 이슈
관련 이슈 번호 #72 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 보상 수여 시 사용자의 기기로 푸시 알림이 즉시 전송되어 보상을 실시간으로 확인 가능
  * 모든 보상 알림이 알림 센터에 자동으로 저장되어 과거 이력을 언제든 조회 가능
  * 실시간 이벤트 기반 알림 처리로 더욱 신속하고 안정적인 서비스 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->