### PR TITLE
Feat/#75 유저 프로필 사진, 학적 정보 변경 기능 구현

### DIFF
--- a/src/main/java/com/campus/campus/domain/user/application/dto/request/ChangeProfileImageRequest.java
+++ b/src/main/java/com/campus/campus/domain/user/application/dto/request/ChangeProfileImageRequest.java
@@ -1,0 +1,9 @@
+package com.campus.campus.domain.user.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ChangeProfileImageRequest(
+	@Schema(description = "새로운 사용자 프로필 이미지", example = "http://image/img_640x640.jpg")
+	String newProfileImage
+) {
+}

--- a/src/main/java/com/campus/campus/domain/user/application/dto/request/ChangeUserAcademicRequest.java
+++ b/src/main/java/com/campus/campus/domain/user/application/dto/request/ChangeUserAcademicRequest.java
@@ -1,0 +1,15 @@
+package com.campus.campus.domain.user.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record ChangeUserAcademicRequest(
+	@Schema(description = "변경할 학교 ID", example = "1")
+	@NotNull
+	Long schoolId,
+
+	@Schema(description = "변경할 학과 ID", example = "15")
+	@NotNull
+	Long majorId
+) {
+}

--- a/src/main/java/com/campus/campus/domain/user/application/dto/response/ChangeProfileImageResponse.java
+++ b/src/main/java/com/campus/campus/domain/user/application/dto/response/ChangeProfileImageResponse.java
@@ -1,0 +1,15 @@
+package com.campus.campus.domain.user.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ChangeProfileImageResponse(
+	@Schema(description = "유저 id", example = "1")
+	Long userId,
+
+	@Schema(description = "유저 닉네임(campusNickname 설정했으면 campusNickname, 아니면, nickname")
+	String nickname,
+
+	@Schema(description = "새로운 사용자 프로필 이미지", example = "http://image/img_640x640.jpg")
+	String newProfileImage
+) {
+}

--- a/src/main/java/com/campus/campus/domain/user/application/dto/response/ChangeUserAcademicResponse.java
+++ b/src/main/java/com/campus/campus/domain/user/application/dto/response/ChangeUserAcademicResponse.java
@@ -1,0 +1,26 @@
+package com.campus.campus.domain.user.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ChangeUserAcademicResponse(
+	@Schema(description = "유저 id", example = "1")
+	Long userId,
+
+	@Schema(description = "유저 닉네임(campusNickname 설정했으면 campusNickname, 아니면, nickname")
+	String nickname,
+
+	@Schema(description = "변경된 학교 이름", example = "가천대학교")
+	String schoolName,
+
+	@Schema(description = "변경된 단과대 이름", example = "IT융합대학")
+	String collegeName,
+
+	@Schema(description = "변경된 학과 이름", example = "소프트웨어학과")
+	String majorName,
+
+	@Schema(description = "다음 변경 가능 날짜", example = "2026-07-15T12:00:00")
+	LocalDateTime nextUpdateAvailableDate
+) {
+}

--- a/src/main/java/com/campus/campus/domain/user/application/exception/AcademicInfoUpdateRestrictionException.java
+++ b/src/main/java/com/campus/campus/domain/user/application/exception/AcademicInfoUpdateRestrictionException.java
@@ -1,0 +1,9 @@
+package com.campus.campus.domain.user.application.exception;
+
+import com.campus.campus.global.common.exception.ApplicationException;
+
+public class AcademicInfoUpdateRestrictionException extends ApplicationException {
+	public AcademicInfoUpdateRestrictionException() {
+		super(ErrorCode.ACADEMIC_INFO_CANNOT_CHANGE);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/user/application/exception/ErrorCode.java
+++ b/src/main/java/com/campus/campus/domain/user/application/exception/ErrorCode.java
@@ -14,7 +14,8 @@ public enum ErrorCode implements ErrorCodeInterface {
 	USER_NOT_FIRST_LOGIN(2101, HttpStatus.BAD_REQUEST, "최초 로그인한 사용가 아닙니다."),
 	NICKNAME_NOT_MATCH(2102, HttpStatus.BAD_REQUEST, "닉네임이 일치하지 않습니다."),
 	USER_SIGNUP_FORBIDDEN_NOW(2103, HttpStatus.FORBIDDEN, "현재 유저 회원가입할 수 없는 계정입니다."),
-	NICKNAME_ALREADY_EXISTS(2104, HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.");
+	NICKNAME_ALREADY_EXISTS(2104, HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
+	ACADEMIC_INFO_CANNOT_CHANGE(2105, HttpStatus.BAD_REQUEST, "학적 정보는 6개월에 한번만 변경 가능합니다.");
 
 	private final int code;
 	private final HttpStatus status;

--- a/src/main/java/com/campus/campus/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/com/campus/campus/domain/user/application/mapper/UserMapper.java
@@ -51,7 +51,7 @@ public class UserMapper {
 	public ChangeUserAcademicResponse toChangeUserAcademicResponse(User user) {
 		return new ChangeUserAcademicResponse(
 			user.getId(),
-			user.getCampusNickname(),
+			user.getCampusNickname() == null ? user.getNickname() : user.getCampusNickname(),
 			user.getSchool().getSchoolName(),
 			user.getMajor().getCollege().getCollegeName(),
 			user.getMajor().getMajorName(),

--- a/src/main/java/com/campus/campus/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/com/campus/campus/domain/user/application/mapper/UserMapper.java
@@ -2,6 +2,7 @@ package com.campus.campus.domain.user.application.mapper;
 
 import org.springframework.stereotype.Component;
 
+import com.campus.campus.domain.user.application.dto.response.ChangeProfileImageResponse;
 import com.campus.campus.domain.user.application.dto.response.UserFirstProfileResponse;
 import com.campus.campus.domain.user.application.dto.response.UserInfoResponse;
 import com.campus.campus.domain.user.domain.entity.User;
@@ -35,6 +36,14 @@ public class UserMapper {
 			user.getSchool().getSchoolName(),
 			user.getCollege().getCollegeName(),
 			user.getMajor().getMajorName()
+		);
+	}
+
+	public ChangeProfileImageResponse toChangeProfileImageResponse(User user) {
+		return new ChangeProfileImageResponse(
+			user.getId(),
+			user.getCampusNickname() == null ? user.getNickname() : user.getCampusNickname(),
+			user.getProfileImage()
 		);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/com/campus/campus/domain/user/application/mapper/UserMapper.java
@@ -3,6 +3,7 @@ package com.campus.campus.domain.user.application.mapper;
 import org.springframework.stereotype.Component;
 
 import com.campus.campus.domain.user.application.dto.response.ChangeProfileImageResponse;
+import com.campus.campus.domain.user.application.dto.response.ChangeUserAcademicResponse;
 import com.campus.campus.domain.user.application.dto.response.UserFirstProfileResponse;
 import com.campus.campus.domain.user.application.dto.response.UserInfoResponse;
 import com.campus.campus.domain.user.domain.entity.User;
@@ -44,6 +45,17 @@ public class UserMapper {
 			user.getId(),
 			user.getCampusNickname() == null ? user.getNickname() : user.getCampusNickname(),
 			user.getProfileImage()
+		);
+	}
+
+	public ChangeUserAcademicResponse toChangeUserAcademicResponse(User user) {
+		return new ChangeUserAcademicResponse(
+			user.getId(),
+			user.getCampusNickname(),
+			user.getSchool().getSchoolName(),
+			user.getMajor().getCollege().getCollegeName(),
+			user.getMajor().getMajorName(),
+			user.getLastProfileUpdatedAt()
 		);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/com/campus/campus/domain/user/application/mapper/UserMapper.java
@@ -55,7 +55,7 @@ public class UserMapper {
 			user.getSchool().getSchoolName(),
 			user.getMajor().getCollege().getCollegeName(),
 			user.getMajor().getMajorName(),
-			user.getLastProfileUpdatedAt()
+			user.getLastProfileUpdatedAt().plusMonths(3)
 		);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/user/application/service/UserService.java
+++ b/src/main/java/com/campus/campus/domain/user/application/service/UserService.java
@@ -1,5 +1,7 @@
 package com.campus.campus.domain.user.application.service;
 
+import java.time.LocalDateTime;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,10 +15,13 @@ import com.campus.campus.domain.school.domain.repository.MajorRepository;
 import com.campus.campus.domain.school.domain.repository.SchoolRepository;
 import com.campus.campus.domain.user.application.dto.request.CampusNicknameUpdateRequest;
 import com.campus.campus.domain.user.application.dto.request.ChangeProfileImageRequest;
+import com.campus.campus.domain.user.application.dto.request.ChangeUserAcademicRequest;
 import com.campus.campus.domain.user.application.dto.request.UserProfileRequest;
 import com.campus.campus.domain.user.application.dto.response.ChangeProfileImageResponse;
+import com.campus.campus.domain.user.application.dto.response.ChangeUserAcademicResponse;
 import com.campus.campus.domain.user.application.dto.response.UserFirstProfileResponse;
 import com.campus.campus.domain.user.application.dto.response.UserInfoResponse;
+import com.campus.campus.domain.user.application.exception.AcademicInfoUpdateRestrictionException;
 import com.campus.campus.domain.user.application.exception.NicknameAlreadyExistsException;
 import com.campus.campus.domain.user.application.exception.UserNotFirstLoginException;
 import com.campus.campus.domain.user.application.exception.UserNotFoundException;
@@ -82,6 +87,34 @@ public class UserService {
 		userRepository.save(user);
 
 		return userMapper.toChangeProfileImageResponse(user);
+	}
+
+	@Transactional
+	public ChangeUserAcademicResponse updateUserAcademic(Long userId, ChangeUserAcademicRequest userAcademicRequest) {
+		User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+			.orElseThrow(UserNotFoundException::new);
+
+		if (user.getLastProfileUpdatedAt() != null) {
+			LocalDateTime nextAvailableDate = user.getLastProfileUpdatedAt().plusMonths(6);
+			if (LocalDateTime.now().isBefore(nextAvailableDate)) {
+				throw new AcademicInfoUpdateRestrictionException();
+			}
+		}
+
+		School school = schoolRepository.findById(userAcademicRequest.schoolId())
+			.orElseThrow(SchoolNotFoundException::new);
+		Major major = majorRepository.findById(userAcademicRequest.majorId())
+			.orElseThrow(MajorNotFoundException::new);
+
+		if (!major.getSchool().getSchoolId().equals(school.getSchoolId())) {
+			throw new SchoolMajorNotSameException();
+		}
+
+		College college = major.getCollege();
+		user.updateProfile(school, college, major);
+		userRepository.save(user);
+
+		return userMapper.toChangeUserAcademicResponse(user);
 	}
 
 	public UserInfoResponse getUserInfo(Long userId) {

--- a/src/main/java/com/campus/campus/domain/user/application/service/UserService.java
+++ b/src/main/java/com/campus/campus/domain/user/application/service/UserService.java
@@ -95,7 +95,7 @@ public class UserService {
 			.orElseThrow(UserNotFoundException::new);
 
 		if (user.getLastProfileUpdatedAt() != null) {
-			LocalDateTime nextAvailableDate = user.getLastProfileUpdatedAt().plusMonths(6);
+			LocalDateTime nextAvailableDate = user.getLastProfileUpdatedAt().plusMonths(3);
 			if (LocalDateTime.now().isBefore(nextAvailableDate)) {
 				throw new AcademicInfoUpdateRestrictionException();
 			}

--- a/src/main/java/com/campus/campus/domain/user/application/service/UserService.java
+++ b/src/main/java/com/campus/campus/domain/user/application/service/UserService.java
@@ -12,7 +12,9 @@ import com.campus.campus.domain.school.domain.entity.School;
 import com.campus.campus.domain.school.domain.repository.MajorRepository;
 import com.campus.campus.domain.school.domain.repository.SchoolRepository;
 import com.campus.campus.domain.user.application.dto.request.CampusNicknameUpdateRequest;
+import com.campus.campus.domain.user.application.dto.request.ChangeProfileImageRequest;
 import com.campus.campus.domain.user.application.dto.request.UserProfileRequest;
+import com.campus.campus.domain.user.application.dto.response.ChangeProfileImageResponse;
 import com.campus.campus.domain.user.application.dto.response.UserFirstProfileResponse;
 import com.campus.campus.domain.user.application.dto.response.UserInfoResponse;
 import com.campus.campus.domain.user.application.exception.NicknameAlreadyExistsException;
@@ -69,6 +71,17 @@ public class UserService {
 
 		user.updateCampusNickname(nicknameUpdateRequest.campusNickname());
 		userRepository.save(user);
+	}
+
+	@Transactional
+	public ChangeProfileImageResponse updateProfileImage(Long userId, ChangeProfileImageRequest profileImageRequest) {
+		User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+			.orElseThrow(UserNotFoundException::new);
+
+		user.updateProfileImage(profileImageRequest.newProfileImage());
+		userRepository.save(user);
+
+		return userMapper.toChangeProfileImageResponse(user);
 	}
 
 	public UserInfoResponse getUserInfo(Long userId) {

--- a/src/main/java/com/campus/campus/domain/user/domain/entity/User.java
+++ b/src/main/java/com/campus/campus/domain/user/domain/entity/User.java
@@ -90,4 +90,8 @@ public class User extends BaseEntity {
 	public void updateRewardNeeded(boolean rewardNeeded) {
 		this.rewardNeeded = rewardNeeded;
 	}
+
+	public void updateProfileImage(String profileImage) {
+		this.profileImage = profileImage;
+	}
 }

--- a/src/main/java/com/campus/campus/domain/user/domain/entity/User.java
+++ b/src/main/java/com/campus/campus/domain/user/domain/entity/User.java
@@ -69,10 +69,14 @@ public class User extends BaseEntity {
 	@JoinColumn(name = "major_id")
 	private Major major;
 
+	@Column(name = "last_profile_updated_at")
+	private LocalDateTime lastProfileUpdatedAt;
+
 	public void updateProfile(School school, College college, Major major) {
 		this.school = school;
 		this.college = college;
 		this.major = major;
+		this.lastProfileUpdatedAt = LocalDateTime.now();
 	}
 
 	public void updateCampusNickname(String campusNickname) {

--- a/src/main/java/com/campus/campus/domain/user/presentation/UserController.java
+++ b/src/main/java/com/campus/campus/domain/user/presentation/UserController.java
@@ -56,7 +56,7 @@ public class UserController {
 		return CommonResponse.success(UserResponseCode.PROFILE_IMAGE_UPDATE_SUCCESS, response);
 	}
 
-	@PatchMapping("/profile/academic")
+	@PatchMapping("change/profile/academic")
 	@Operation(summary = "사용자 학적 정보 수정 (3개월 1회 제한)")
 	public CommonResponse<ChangeUserAcademicResponse> updateAcademicInfo(@CurrentUserId Long userId,
 		@RequestBody @Valid ChangeUserAcademicRequest changeUserAcademicRequest) {

--- a/src/main/java/com/campus/campus/domain/user/presentation/UserController.java
+++ b/src/main/java/com/campus/campus/domain/user/presentation/UserController.java
@@ -57,7 +57,7 @@ public class UserController {
 	}
 
 	@PatchMapping("/profile/academic")
-	@Operation(summary = "사용자 학적 정보 수정 (6개월 1회 제한)")
+	@Operation(summary = "사용자 학적 정보 수정 (3개월 1회 제한)")
 	public CommonResponse<ChangeUserAcademicResponse> updateAcademicInfo(@CurrentUserId Long userId,
 		@RequestBody @Valid ChangeUserAcademicRequest changeUserAcademicRequest) {
 		ChangeUserAcademicResponse response = userService.updateUserAcademic(userId, changeUserAcademicRequest);

--- a/src/main/java/com/campus/campus/domain/user/presentation/UserController.java
+++ b/src/main/java/com/campus/campus/domain/user/presentation/UserController.java
@@ -8,8 +8,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.campus.campus.domain.user.application.dto.request.CampusNicknameUpdateRequest;
 import com.campus.campus.domain.user.application.dto.request.ChangeProfileImageRequest;
+import com.campus.campus.domain.user.application.dto.request.ChangeUserAcademicRequest;
 import com.campus.campus.domain.user.application.dto.request.UserProfileRequest;
 import com.campus.campus.domain.user.application.dto.response.ChangeProfileImageResponse;
+import com.campus.campus.domain.user.application.dto.response.ChangeUserAcademicResponse;
 import com.campus.campus.domain.user.application.dto.response.UserFirstProfileResponse;
 import com.campus.campus.domain.user.application.dto.response.UserInfoResponse;
 import com.campus.campus.domain.user.application.service.UserService;
@@ -45,13 +47,22 @@ public class UserController {
 	}
 
 
-	@PatchMapping
+	@PatchMapping("/change/profile-image/")
 	@Operation(summary = "사용자 프로필 이미지 변경")
 	public CommonResponse<ChangeProfileImageResponse> updateProfileImage(@CurrentUserId Long userId,
 		@RequestBody @Valid ChangeProfileImageRequest changeProfileImageRequest) {
 		ChangeProfileImageResponse response = userService.updateProfileImage(userId, changeProfileImageRequest);
 
 		return CommonResponse.success(UserResponseCode.PROFILE_IMAGE_UPDATE_SUCCESS, response);
+	}
+
+	@PatchMapping("/profile/academic")
+	@Operation(summary = "사용자 학적 정보 수정 (6개월 1회 제한)")
+	public CommonResponse<ChangeUserAcademicResponse> updateAcademicInfo(@CurrentUserId Long userId,
+		@RequestBody @Valid ChangeUserAcademicRequest changeUserAcademicRequest) {
+		ChangeUserAcademicResponse response = userService.updateUserAcademic(userId, changeUserAcademicRequest);
+
+		return CommonResponse.success(UserResponseCode.ACADEMIC_INFO_UPDATE_SUCCESS, response);
 	}
 
 	@GetMapping

--- a/src/main/java/com/campus/campus/domain/user/presentation/UserController.java
+++ b/src/main/java/com/campus/campus/domain/user/presentation/UserController.java
@@ -47,7 +47,7 @@ public class UserController {
 	}
 
 
-	@PatchMapping("/change/profile-image/")
+	@PatchMapping("/change/profile/image")
 	@Operation(summary = "사용자 프로필 이미지 변경")
 	public CommonResponse<ChangeProfileImageResponse> updateProfileImage(@CurrentUserId Long userId,
 		@RequestBody @Valid ChangeProfileImageRequest changeProfileImageRequest) {

--- a/src/main/java/com/campus/campus/domain/user/presentation/UserController.java
+++ b/src/main/java/com/campus/campus/domain/user/presentation/UserController.java
@@ -7,7 +7,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.campus.campus.domain.user.application.dto.request.CampusNicknameUpdateRequest;
+import com.campus.campus.domain.user.application.dto.request.ChangeProfileImageRequest;
 import com.campus.campus.domain.user.application.dto.request.UserProfileRequest;
+import com.campus.campus.domain.user.application.dto.response.ChangeProfileImageResponse;
 import com.campus.campus.domain.user.application.dto.response.UserFirstProfileResponse;
 import com.campus.campus.domain.user.application.dto.response.UserInfoResponse;
 import com.campus.campus.domain.user.application.service.UserService;
@@ -40,6 +42,16 @@ public class UserController {
 		userService.updateCampusNickname(userId, nicknameUpdateRequest);
 
 		return CommonResponse.success(UserResponseCode.NICKNAME_UPDATE_SUCCESS);
+	}
+
+
+	@PatchMapping
+	@Operation(summary = "사용자 프로필 이미지 변경")
+	public CommonResponse<ChangeProfileImageResponse> updateProfileImage(@CurrentUserId Long userId,
+		@RequestBody @Valid ChangeProfileImageRequest changeProfileImageRequest) {
+		ChangeProfileImageResponse response = userService.updateProfileImage(userId, changeProfileImageRequest);
+
+		return CommonResponse.success(UserResponseCode.PROFILE_IMAGE_UPDATE_SUCCESS, response);
 	}
 
 	@GetMapping

--- a/src/main/java/com/campus/campus/domain/user/presentation/UserResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/user/presentation/UserResponseCode.java
@@ -14,7 +14,8 @@ public enum UserResponseCode implements ResponseCodeInterface {
 	FIRST_PROFILE_WRITE(200, HttpStatus.OK, " 프로필(학교 정보) 입력에 성공했습니다."),
 	NICKNAME_UPDATE_SUCCESS(200, HttpStatus.OK, "닉네임 변경에 성공했습니다."),
 	WITHDRAW_SUCCESS(200, HttpStatus.OK, "회원탈퇴에 성공했습니다."),
-	GET_USER_INFO_SUCCESS(200, HttpStatus.OK, "유저 정보 조회에 성공했습니다.");
+	GET_USER_INFO_SUCCESS(200, HttpStatus.OK, "유저 정보 조회에 성공했습니다."),
+	PROFILE_IMAGE_UPDATE_SUCCESS(200, HttpStatus.OK, "유저 프로필 이미지 변경에 성공했습니다.");
 
 	private final int code;
 	private final HttpStatus status;

--- a/src/main/java/com/campus/campus/domain/user/presentation/UserResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/user/presentation/UserResponseCode.java
@@ -15,7 +15,8 @@ public enum UserResponseCode implements ResponseCodeInterface {
 	NICKNAME_UPDATE_SUCCESS(200, HttpStatus.OK, "닉네임 변경에 성공했습니다."),
 	WITHDRAW_SUCCESS(200, HttpStatus.OK, "회원탈퇴에 성공했습니다."),
 	GET_USER_INFO_SUCCESS(200, HttpStatus.OK, "유저 정보 조회에 성공했습니다."),
-	PROFILE_IMAGE_UPDATE_SUCCESS(200, HttpStatus.OK, "유저 프로필 이미지 변경에 성공했습니다.");
+	PROFILE_IMAGE_UPDATE_SUCCESS(200, HttpStatus.OK, "유저 프로필 이미지 변경에 성공했습니다."),
+	ACADEMIC_INFO_UPDATE_SUCCESS(200, HttpStatus.OK, "유저 학적 정보 변경에 성공했습니다.");
 
 	private final int code;
 	private final HttpStatus status;


### PR DESCRIPTION
## 🔀 변경 내용
- 유저 프로필 사진, 학적 정보 변경 기능 구현했습니다.

## ✅ 작업 항목
- [x] 유저 프로필 사진 변경 기능 구현
- [x] 유저 학적 정보 변경 기능 구현 (6개월에 한번 가능, lastProfileUpdatedAt컬럼 추가)

## 📸 스크린샷 (선택)
### 유저 프로필 사진 변경
<img width="1457" height="342" alt="image" src="https://github.com/user-attachments/assets/ba48ff52-5dc2-48d9-87af-253b26283322" />

### 유저 학저 정보 변경
<img width="1467" height="391" alt="image" src="https://github.com/user-attachments/assets/fa19d337-9d97-4278-9002-bef30715ab4b" />
<img width="1458" height="289" alt="image" src="https://github.com/user-attachments/assets/f7b6a790-3b00-4446-a608-d22409bb7631" />


## 📎 참고 이슈
관련 이슈 번호 #75 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 사용자 프로필 이미지 변경 기능 추가 — 변경 결과(유저 ID, 닉네임, 새 이미지)를 반환합니다.
  * 학적 정보(학교·대학·학과) 변경 기능 추가 — 6개월 주기 제한이 적용됩니다.
  * 프로필 업데이트 시각 기록 추가 — 마지막 변경 가능 시점이 관리됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->