### PR TITLE
Feat/#77 학생회 프로필 이미지 수정 기능 추가

### DIFF
--- a/src/main/java/com/campus/campus/domain/council/application/dto/request/StudentCouncilChangeProfileImageRequest.java
+++ b/src/main/java/com/campus/campus/domain/council/application/dto/request/StudentCouncilChangeProfileImageRequest.java
@@ -1,0 +1,9 @@
+package com.campus.campus.domain.council.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record StudentCouncilChangeProfileImageRequest(
+	@Schema(description = "학생회 프로필 이미지 url", example = "https://www.example.com.png")
+	String councilProfileImageUrl
+) {
+}

--- a/src/main/java/com/campus/campus/domain/council/application/dto/response/StudentCouncilChangeProfileImageResponse.java
+++ b/src/main/java/com/campus/campus/domain/council/application/dto/response/StudentCouncilChangeProfileImageResponse.java
@@ -1,0 +1,15 @@
+package com.campus.campus.domain.council.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record StudentCouncilChangeProfileImageResponse(
+	@Schema(description = "학생회 ID", example = "1")
+	Long councilId,
+
+	@Schema(description = "학생회 이름", example = "가천대학교 총학생회")
+	String councilName,
+
+	@Schema(description = "학생회 프로필 이미지 url", example = "https://www.example.com.png")
+	String councilProfileImageUrl
+) {
+}

--- a/src/main/java/com/campus/campus/domain/council/application/dto/response/StudentCouncilLoginResponse.java
+++ b/src/main/java/com/campus/campus/domain/council/application/dto/response/StudentCouncilLoginResponse.java
@@ -38,6 +38,9 @@ public record StudentCouncilLoginResponse(
 	String councilName,
 
 	@Schema(description = "학생회 닉네임", example = "CUBE")
-	String councilNickname
+	String councilNickname,
+
+	@Schema(description = "학생회 프로필 이미지 url", example = "https://www.example.com.png")
+	String councilProfileImageUrl
 ) {
 }

--- a/src/main/java/com/campus/campus/domain/council/application/mapper/StudentCouncilMapper.java
+++ b/src/main/java/com/campus/campus/domain/council/application/mapper/StudentCouncilMapper.java
@@ -50,7 +50,8 @@ public class StudentCouncilMapper {
 			studentCouncil.getCollege() != null ? studentCouncil.getCollege().getCollegeName() : null,
 			studentCouncil.getMajor() != null ? studentCouncil.getMajor().getMajorName() : null,
 			studentCouncil.getCouncilName(),
-			studentCouncil.getCouncilNickname()
+			studentCouncil.getCouncilNickname(),
+			studentCouncil.getCouncilProfileImageUrl()
 		);
 	}
 

--- a/src/main/java/com/campus/campus/domain/council/application/mapper/StudentCouncilMapper.java
+++ b/src/main/java/com/campus/campus/domain/council/application/mapper/StudentCouncilMapper.java
@@ -3,6 +3,7 @@ package com.campus.campus.domain.council.application.mapper;
 import org.springframework.stereotype.Component;
 
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilSignUpRequest;
+import com.campus.campus.domain.council.application.dto.response.StudentCouncilChangeProfileImageResponse;
 import com.campus.campus.domain.council.application.dto.response.StudentCouncilFindIdResponse;
 import com.campus.campus.domain.council.application.dto.response.StudentCouncilLoginResponse;
 import com.campus.campus.domain.council.application.dto.response.StudentCouncilNicknameResponse;
@@ -63,6 +64,15 @@ public class StudentCouncilMapper {
 		return new StudentCouncilNicknameResponse(
 			studentCouncil.getCouncilNickname(),
 			studentCouncil.getCouncilName()
+		);
+	}
+
+	public StudentCouncilChangeProfileImageResponse toStudentCouncilChangeProfileImageResponse(
+		StudentCouncil studentCouncil) {
+		return new StudentCouncilChangeProfileImageResponse(
+			studentCouncil.getId(),
+			studentCouncil.getCouncilName(),
+			studentCouncil.getCouncilProfileImageUrl()
 		);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/council/application/service/CouncilService.java
+++ b/src/main/java/com/campus/campus/domain/council/application/service/CouncilService.java
@@ -5,7 +5,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilChangeEmailRequest;
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilChangePasswordRequest;
+import com.campus.campus.domain.council.application.dto.request.StudentCouncilChangeProfileImageRequest;
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilNicknameRequest;
+import com.campus.campus.domain.council.application.dto.response.StudentCouncilChangeProfileImageResponse;
 import com.campus.campus.domain.council.application.dto.response.StudentCouncilNicknameResponse;
 import com.campus.campus.domain.council.application.exception.EmailAlreadyExistsException;
 import com.campus.campus.domain.council.application.exception.NewPasswordConfirmNotMatchException;
@@ -91,6 +93,19 @@ public class CouncilService {
 		studentCouncilRepository.save(studentCouncil);
 
 		return studentCouncilMapper.toStudentCouncilNicknameResponse(studentCouncil);
+	}
+
+	@Transactional
+	public StudentCouncilChangeProfileImageResponse changeCouncilProfileImage(Long councilId,
+		StudentCouncilChangeProfileImageRequest studentCouncilChangeProfileImageRequest) {
+		StudentCouncil studentCouncil = studentCouncilRepository
+			.findByIdAndManagerApprovedIsTrueAndDeletedAtIsNull(councilId)
+			.orElseThrow(StudentCouncilNotFoundException::new);
+
+		studentCouncil.updateCouncilProfileImage(studentCouncilChangeProfileImageRequest.councilProfileImageUrl());
+		studentCouncilRepository.save(studentCouncil);
+
+		return studentCouncilMapper.toStudentCouncilChangeProfileImageResponse(studentCouncil);
 	}
 
 	private EmailVerification getVerifiedChangeEmail(Long councilId, String email) {

--- a/src/main/java/com/campus/campus/domain/council/domain/entity/StudentCouncil.java
+++ b/src/main/java/com/campus/campus/domain/council/domain/entity/StudentCouncil.java
@@ -21,6 +21,7 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -68,6 +69,10 @@ public class StudentCouncil extends BaseEntity {
 	@Column(name = "council_nickname")
 	private String councilNickname;
 
+	@Column(name = "council_profile_image_url")
+	@Builder.Default
+	private String councilProfileImageUrl = null;
+
 	@Column(name = "election_image_url")
 	private String electionImageUrl;
 
@@ -91,6 +96,10 @@ public class StudentCouncil extends BaseEntity {
 
 	public void updateCouncilNickname(String nickname) {
 		this.councilNickname = nickname;
+	}
+
+	public void updateCouncilProfileImage(String newProfileImageUrl) {
+		this.councilProfileImageUrl = newProfileImageUrl;
 	}
 
 	public void generateCouncilName(String councilName) {

--- a/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilController.java
+++ b/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilController.java
@@ -8,7 +8,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilChangeEmailRequest;
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilChangePasswordRequest;
+import com.campus.campus.domain.council.application.dto.request.StudentCouncilChangeProfileImageRequest;
 import com.campus.campus.domain.council.application.dto.request.StudentCouncilNicknameRequest;
+import com.campus.campus.domain.council.application.dto.response.StudentCouncilChangeProfileImageResponse;
 import com.campus.campus.domain.council.application.dto.response.StudentCouncilNicknameResponse;
 import com.campus.campus.domain.council.application.service.CouncilService;
 import com.campus.campus.global.annotation.CurrentCouncilId;
@@ -51,5 +53,16 @@ public class StudentCouncilController {
 			studentCouncilNicknameRequest);
 
 		return CommonResponse.success(StudentCouncilResponseCode.CHANGE_NICKNAME_SUCCESS, response);
+	}
+
+	@PatchMapping("/change/image")
+	@Operation(summary = "학생회 프로필 이미지 변경")
+	public CommonResponse<StudentCouncilChangeProfileImageResponse> changeProfileImage(
+		@CurrentCouncilId Long councilId,
+		@Valid @RequestBody StudentCouncilChangeProfileImageRequest studentCouncilChangeProfileImageRequest) {
+		StudentCouncilChangeProfileImageResponse response = councilService.changeCouncilProfileImage(councilId,
+			studentCouncilChangeProfileImageRequest);
+
+		return CommonResponse.success(StudentCouncilResponseCode.CHANGE_PROFILE_IMAGE_SUCCESS, response);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilResponseCode.java
@@ -19,6 +19,7 @@ public enum StudentCouncilResponseCode implements ResponseCodeInterface {
 	CHANGE_EMAIL_SUCCESS(200, HttpStatus.OK, "이메일 변경에 성공했습니다."),
 	CHANGE_PASSWORD_SUCCESS(200, HttpStatus.OK, "비밀번호 변경에 성공했습니다."),
 	CHANGE_NICKNAME_SUCCESS(200, HttpStatus.OK, "학생회 닉네임 변경에 성공했습니다."),
+	CHANGE_PROFILE_IMAGE_SUCCESS(200,HttpStatus.OK,"학생회 프로필 이미지 변경에 성공했습니다."),
 	COUNCIL_WITHDRAW_SUCCESS(200, HttpStatus.OK, "학생회 회원탈퇴에 성공했습니다.");
 
 	private final int code;


### PR DESCRIPTION
## 🔀 변경 내용
- 학생회 프로필 이미지 수정 기능 추가했습니다.

## ✅ 작업 항목
- [x] 학생회 프로필 이미지 수정 기능 추가
- [x] 학생회 로그인 시 반환값에 프로필 이미지 url 추가

## 📸 스크린샷 (선택)
### 프로필 이미지 수정
<img width="1441" height="343" alt="image" src="https://github.com/user-attachments/assets/3d4046fb-0214-4153-be8e-fe3f923d968b" />

### 로그인 시 반환값에 프로필 이미지 url 추가
<img width="1454" height="520" alt="image" src="https://github.com/user-attachments/assets/5473ba33-f062-4559-942b-77da132944a2" />


## 📎 참고 이슈
관련 이슈 번호 #77 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **학생회 프로필 이미지 변경 기능**
  * 학생회에서 프로필 이미지를 손쉽게 변경할 수 있는 새로운 기능이 추가되었습니다.
  * 학생회 프로필 이미지는 로그인 시 자동으로 함께 반환되어 앱에서 바로 확인할 수 있습니다.
  * 프로필 이미지 변경 후 즉시 시스템에 반영됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->