### PR TITLE
Refactor/#79 학생회 인증자(회장) 컬럼 추가 및 관리자 인증 시 인증자 정보 입력 구현

### DIFF
--- a/src/main/java/com/campus/campus/domain/council/application/dto/response/StudentCouncilLoginResponse.java
+++ b/src/main/java/com/campus/campus/domain/council/application/dto/response/StudentCouncilLoginResponse.java
@@ -41,6 +41,9 @@ public record StudentCouncilLoginResponse(
 	String councilNickname,
 
 	@Schema(description = "학생회 프로필 이미지 url", example = "https://www.example.com.png")
-	String councilProfileImageUrl
+	String councilProfileImageUrl,
+
+	@Schema(description = "학생회 대표자 이름", example = "한승현")
+	String councilPresident
 ) {
 }

--- a/src/main/java/com/campus/campus/domain/council/application/mapper/StudentCouncilMapper.java
+++ b/src/main/java/com/campus/campus/domain/council/application/mapper/StudentCouncilMapper.java
@@ -51,7 +51,8 @@ public class StudentCouncilMapper {
 			studentCouncil.getMajor() != null ? studentCouncil.getMajor().getMajorName() : null,
 			studentCouncil.getCouncilName(),
 			studentCouncil.getCouncilNickname(),
-			studentCouncil.getCouncilProfileImageUrl()
+			studentCouncil.getCouncilProfileImageUrl(),
+			studentCouncil.getCouncilPresident()
 		);
 	}
 

--- a/src/main/java/com/campus/campus/domain/council/domain/entity/StudentCouncil.java
+++ b/src/main/java/com/campus/campus/domain/council/domain/entity/StudentCouncil.java
@@ -76,6 +76,10 @@ public class StudentCouncil extends BaseEntity {
 	@Column(name = "election_image_url")
 	private String electionImageUrl;
 
+	@Column(name = "council_president")
+	@Builder.Default
+	private String councilPresident = null;
+
 	@Column(name = "manager_approved", nullable = false)
 	private boolean managerApproved;
 
@@ -104,6 +108,10 @@ public class StudentCouncil extends BaseEntity {
 
 	public void generateCouncilName(String councilName) {
 		this.councilName = councilName;
+	}
+
+	public void updateCouncilPresident(String president) {
+		this.councilPresident = president;
 	}
 
 	public void managerApprove() {

--- a/src/main/java/com/campus/campus/domain/manager/application/dto/request/CouncilApproveOrDenyRequest.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/dto/request/CouncilApproveOrDenyRequest.java
@@ -6,6 +6,9 @@ import jakarta.validation.constraints.NotNull;
 public record CouncilApproveOrDenyRequest(
 	@NotNull
 	@Schema(description = "인증 결과", example = "true")
-	boolean certifyResult
+	boolean certifyResult,
+
+	@Schema(description = "학생회 대표자 이름", example = "한승현")
+	String councilPresident
 ) {
 }

--- a/src/main/java/com/campus/campus/domain/manager/application/dto/response/CouncilApproveOrDenyResponse.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/dto/response/CouncilApproveOrDenyResponse.java
@@ -7,6 +7,9 @@ public record CouncilApproveOrDenyResponse(
 	Long councilId,
 
 	@Schema(description = "인증 결과", example = "true")
-	boolean certifyResult
+	boolean certifyResult,
+
+	@Schema(description = "학생회 대표자 이름", example = "한승현")
+	String councilPresident
 ) {
 }

--- a/src/main/java/com/campus/campus/domain/manager/application/mapper/ManagerMapper.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/mapper/ManagerMapper.java
@@ -27,10 +27,12 @@ public class ManagerMapper {
 		);
 	}
 
-	public CouncilApproveOrDenyResponse toCouncilApproveOrDenyResponse(Long councilId, boolean certifyResult) {
+	public CouncilApproveOrDenyResponse toCouncilApproveOrDenyResponse(Long councilId, boolean certifyResult,
+		String councilPresident) {
 		return new CouncilApproveOrDenyResponse(
 			councilId,
-			certifyResult
+			certifyResult,
+			councilPresident
 		);
 	}
 

--- a/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
@@ -80,6 +80,7 @@ public class ManagerService {
 
 		if (certifyResult) {
 			studentCouncil.managerApprove();
+			studentCouncil.updateCouncilPresident(councilApproveOrDenyRequest.councilPresident());
 			studentCouncilRepository.save(studentCouncil);
 
 			sendCouncilApprovedMail(studentCouncil.getEmail());
@@ -87,7 +88,8 @@ public class ManagerService {
 			sendCouncilDeniedMail(studentCouncil.getEmail());
 		}
 
-		return managerMapper.toCouncilApproveOrDenyResponse(studentCouncil.getId(), certifyResult);
+		return managerMapper.toCouncilApproveOrDenyResponse(studentCouncil.getId(), certifyResult,
+			studentCouncil.getCouncilPresident());
 	}
 
 	public List<CertifyRequestCouncilListResponse> getCertifyRequestCouncils() {


### PR DESCRIPTION
## 🔀 변경 내용
- 학생회 인증자(회장) 컬럼 추가 및 관리자 인증 시 인증자 정보 입력 구현했습니다.

## ✅ 작업 항목
- [x] 관리자 인증 시 인증자 정보 입력 구현(councilPresident 컬럼 추가) (관리자가 당선정보를 보고 직접 입력)
- [x] 학생회 로그인 시 학생회 인증자(회장)의 이름이 반환되도록 수정

## 📸 스크린샷 (선택)
### 관리자 인증 시 인증자 정보 입력
<img width="1467" height="359" alt="image" src="https://github.com/user-attachments/assets/4e65dc24-d4a4-41fe-af24-ad0abd6a1341" />

### 학생회 로그인
<img width="1461" height="533" alt="image" src="https://github.com/user-attachments/assets/ca2c7959-6ac6-412c-9df1-447d9a6f8206" />

## 📎 참고 이슈
관련 이슈 번호 #79 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 학생회 로그인 응답에 현재 학생회장 정보가 포함되어 사용자가 학생회장을 확인할 수 있습니다.
* 학생회 승인 및 거부 절차에서 학생회장 정보를 지정하고 관리할 수 있으며, 승인 완료 시 시스템이 학생회장 정보를 자동으로 업데이트하고 저장합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->