### PR TITLE
feat/#82: 사용자 소속 id 조회 기능 구현

### DIFF
--- a/src/main/java/com/campus/campus/domain/user/application/dto/response/UserInfoIdsResponse.java
+++ b/src/main/java/com/campus/campus/domain/user/application/dto/response/UserInfoIdsResponse.java
@@ -1,0 +1,9 @@
+package com.campus.campus.domain.user.application.dto.response;
+
+public record UserInfoIdsResponse(
+	Long userId,
+	Long schoolId,
+	Long collegeId,
+	Long majorId
+) {
+}

--- a/src/main/java/com/campus/campus/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/com/campus/campus/domain/user/application/mapper/UserMapper.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import com.campus.campus.domain.user.application.dto.response.ChangeProfileImageResponse;
 import com.campus.campus.domain.user.application.dto.response.ChangeUserAcademicResponse;
 import com.campus.campus.domain.user.application.dto.response.UserFirstProfileResponse;
+import com.campus.campus.domain.user.application.dto.response.UserInfoIdsResponse;
 import com.campus.campus.domain.user.application.dto.response.UserInfoResponse;
 import com.campus.campus.domain.user.domain.entity.User;
 
@@ -58,4 +59,14 @@ public class UserMapper {
 			user.getLastProfileUpdatedAt().plusMonths(3)
 		);
 	}
+
+	public UserInfoIdsResponse toUserInfoIdsResponse(User user) {
+		return new UserInfoIdsResponse(
+			user.getId(),
+			user.getSchool().getSchoolId(),
+			user.getCollege() == null ? null : user.getCollege().getCollegeId(),
+			user.getMajor() == null ? null : user.getMajor().getMajorId()
+		);
+	}
+
 }

--- a/src/main/java/com/campus/campus/domain/user/application/service/UserService.java
+++ b/src/main/java/com/campus/campus/domain/user/application/service/UserService.java
@@ -20,6 +20,7 @@ import com.campus.campus.domain.user.application.dto.request.UserProfileRequest;
 import com.campus.campus.domain.user.application.dto.response.ChangeProfileImageResponse;
 import com.campus.campus.domain.user.application.dto.response.ChangeUserAcademicResponse;
 import com.campus.campus.domain.user.application.dto.response.UserFirstProfileResponse;
+import com.campus.campus.domain.user.application.dto.response.UserInfoIdsResponse;
 import com.campus.campus.domain.user.application.dto.response.UserInfoResponse;
 import com.campus.campus.domain.user.application.exception.AcademicInfoUpdateRestrictionException;
 import com.campus.campus.domain.user.application.exception.NicknameAlreadyExistsException;
@@ -123,4 +124,12 @@ public class UserService {
 
 		return userMapper.toUserInfoResponse(user);
 	}
+
+	public UserInfoIdsResponse getUserInfoIds(Long userId) {
+		User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+			.orElseThrow(UserNotFoundException::new);
+
+		return userMapper.toUserInfoIdsResponse(user);
+	}
+
 }

--- a/src/main/java/com/campus/campus/domain/user/presentation/UserController.java
+++ b/src/main/java/com/campus/campus/domain/user/presentation/UserController.java
@@ -13,6 +13,7 @@ import com.campus.campus.domain.user.application.dto.request.UserProfileRequest;
 import com.campus.campus.domain.user.application.dto.response.ChangeProfileImageResponse;
 import com.campus.campus.domain.user.application.dto.response.ChangeUserAcademicResponse;
 import com.campus.campus.domain.user.application.dto.response.UserFirstProfileResponse;
+import com.campus.campus.domain.user.application.dto.response.UserInfoIdsResponse;
 import com.campus.campus.domain.user.application.dto.response.UserInfoResponse;
 import com.campus.campus.domain.user.application.service.UserService;
 import com.campus.campus.global.annotation.CurrentUserId;
@@ -72,4 +73,12 @@ public class UserController {
 
 		return CommonResponse.success(UserResponseCode.GET_USER_INFO_SUCCESS, userInfoResponse);
 	}
+
+	@GetMapping("/ids")
+	@Operation(summary = "사용자 소속 정보 조회(Topic 구독) - ID만")
+	public CommonResponse<UserInfoIdsResponse> getUserInfoIdsInfo(@CurrentUserId Long userId) {
+		UserInfoIdsResponse res = userService.getUserInfoIds(userId);
+		return CommonResponse.success(UserResponseCode.GET_USER_INFO_SUCCESS, res);
+	}
+
 }


### PR DESCRIPTION
## 🔀 변경 내용
- 알림 구독을 위한 사용자 소속 id 조회 기능 구현

## ✅ 작업 항목
- [x] getUserInfoIds
- [x] 테스트 완료 여부

## 📸 스크린샷 (선택)
<img width="734" height="340" alt="image" src="https://github.com/user-attachments/assets/45a3c8b8-fdaa-48d3-a8b4-6e8b3ff1e552" />

## 📎 참고 이슈
관련 이슈 번호 #82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 소속 ID 정보를 조회하는 새로운 API 엔드포인트 추가
  * 사용자 ID, 학교 ID, 단과대 ID, 전공 ID를 한 번에 조회 가능

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->