### PR TITLE
 refactor/#92: 사용자 학교 이메일 및 학적 정보 중앙대 제한 기능 구현

### DIFF
--- a/src/main/java/com/campus/campus/domain/mail/application/exception/CauEmailRequiredException.java
+++ b/src/main/java/com/campus/campus/domain/mail/application/exception/CauEmailRequiredException.java
@@ -1,0 +1,9 @@
+package com.campus.campus.domain.mail.application.exception;
+
+import com.campus.campus.global.common.exception.ApplicationException;
+
+public class CauEmailRequiredException extends ApplicationException {
+	public CauEmailRequiredException() {
+		super(ErrorCode.CAU_EMAIL_REQUIRED);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/mail/application/exception/ErrorCode.java
+++ b/src/main/java/com/campus/campus/domain/mail/application/exception/ErrorCode.java
@@ -15,7 +15,9 @@ public enum ErrorCode implements ErrorCodeInterface {
 	VERIFICATION_CODE_NOT_MATCH(2402, HttpStatus.BAD_REQUEST, "인증 코드가 일치하지 않습니다."),
 	EMAIL_NOT_VERIFIED(2403, HttpStatus.UNAUTHORIZED, "이메일 인증이 되지 않았습니다."),
 	INVALID_SCHOOL_EMAIL(2404, HttpStatus.BAD_REQUEST, "학교 이메일(.ac.kr 혹은 .edu)만 인증 가능합니다."),
-	VERIFICATION_INVALID(2405, HttpStatus.BAD_REQUEST, "유효하지 않은 인증 정보입니다.");
+	VERIFICATION_INVALID(2405, HttpStatus.BAD_REQUEST, "유효하지 않은 인증 정보입니다."),
+
+	CAU_EMAIL_REQUIRED(2406, HttpStatus.BAD_REQUEST, "중앙대학교 학생만 가입할 수 있습니다.");
 
 	private final int code;
 	private final HttpStatus status;

--- a/src/main/java/com/campus/campus/domain/mail/application/service/EmailVerificationService.java
+++ b/src/main/java/com/campus/campus/domain/mail/application/service/EmailVerificationService.java
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.campus.campus.domain.mail.application.dto.request.EmailVerificationConfirmRequest;
+import com.campus.campus.domain.mail.application.exception.CauEmailRequiredException;
 import com.campus.campus.domain.mail.application.exception.EmailVerificationNotFoundException;
-import com.campus.campus.domain.mail.application.exception.InvalidSchoolEmailException;
 import com.campus.campus.domain.mail.application.exception.VerificationCodeExpiredException;
 import com.campus.campus.domain.mail.application.exception.VerificationCodeNotMatchException;
 import com.campus.campus.domain.mail.application.mapper.EmailVerificationMapper;
@@ -25,8 +25,10 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class EmailVerificationService {
 	private static final long EXPIRE_TIME = 5L;
-	private static final String SCHOOL_EMAIL_SUFFIX_AC = ".ac.kr";
-	private static final String SCHOOL_EMAIL_SUFFIX_EDU = ".edu";
+
+	// private static final String SCHOOL_EMAIL_SUFFIX_AC = ".ac.kr";
+	// private static final String SCHOOL_EMAIL_SUFFIX_EDU = ".edu";
+	private static final String CAU_EMAIL_DOMAIN = "@cau.ac.kr";
 
 	private final JavaMailSender javaMailSender;
 	private final EmailVerificationMapper emailVerificationMapper;
@@ -188,9 +190,16 @@ public class EmailVerificationService {
 		return String.valueOf(code);
 	}
 
+	//모든 학교 허용 시, 주석 해제
+	// private void validateSchoolEmail(String email) {
+	// 	if (!email.endsWith(SCHOOL_EMAIL_SUFFIX_AC) && !email.endsWith(SCHOOL_EMAIL_SUFFIX_EDU)) {
+	// 		throw new InvalidSchoolEmailException();
+	// 	}
+	// }
 	private void validateSchoolEmail(String email) {
-		if (!email.endsWith(SCHOOL_EMAIL_SUFFIX_AC) && !email.endsWith(SCHOOL_EMAIL_SUFFIX_EDU)) {
-			throw new InvalidSchoolEmailException();
+		String normalized = (email == null) ? "" : email.trim().toLowerCase();
+		if (!normalized.endsWith(CAU_EMAIL_DOMAIN)) {
+			throw new CauEmailRequiredException();
 		}
 	}
 }

--- a/src/main/java/com/campus/campus/domain/review/application/service/OcrService.java
+++ b/src/main/java/com/campus/campus/domain/review/application/service/OcrService.java
@@ -22,126 +22,126 @@ import com.campus.campus.domain.review.application.exception.ReceiptDateParseExc
 import com.campus.campus.domain.review.application.exception.ReceiptFileConvertException;
 import com.campus.campus.domain.review.application.exception.ReceiptOcrFailedException;
 import com.campus.campus.domain.review.application.mapper.ReviewMapper;
-import com.campus.campus.domain.review.infrastructure.ClovaOcrClient;
+// import com.campus.campus.domain.review.infrastructure.ClovaOcrClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
-@Service
-@Slf4j
-@RequiredArgsConstructor
-public class OcrService {
-
-	private final ClovaOcrClient clovaOcrClient;
-	private final ObjectMapper objectMapper;
-	private final ReviewService reviewService;
-	private final ReviewMapper reviewMapper;
-	private final PlaceRepository placeRepository;
-
-	public ReviewPartnerResponse processReceipt(MultipartFile file, Long userId, Long placeId) {
-		Place place = placeRepository.findById(placeId)
-			.orElseThrow(PlaceInfoNotFoundException::new);
-
-		//MultipartFIle -> byte[]
-		byte[] imageBytes;
-		try {
-			imageBytes = file.getBytes();
-		} catch (IOException e) {
-			throw new ReceiptFileConvertException();
-		}
-
-		//ocr
-		String rawResponse = clovaOcrClient.requestReceiptOcr(imageBytes, file.getOriginalFilename());
-		log.debug("[OCR RAW RESPONSE] {}", rawResponse);
-
-		ReceiptOcrResponse ocrResponse = parse(rawResponse);
-		ReceiptResultDto result = extractReceiptResult(ocrResponse);
-		log.info("영수증 ocr 인식 결과:{}", result);
-
-		return reviewService.findPartnership(place.getPlaceId(), result, userId);
-	}
-
-	private ReceiptOcrResponse parse(String json) {
-		try {
-			log.debug("[OCR PARSE INPUT] {}", json);
-			return objectMapper.readValue(json, ReceiptOcrResponse.class);
-		} catch (Exception e) {
-			log.error("[OCR PARSE FAILED] raw={}", json, e);
-			throw new ReceiptOcrFailedException();
-		}
-	}
-
-	private ReceiptResultDto extractReceiptResult(ReceiptOcrResponse response) {
-		log.info("[OCR RESPONSE] images size={}",
-			response.images() != null ? response.images().size() : null);
-
-		var images = Optional.ofNullable(response.images()).orElse(List.of());
-		var image = images.stream()
-			.findFirst()
-			.orElseThrow(() -> {
-				log.warn("[OCR FAILED] images empty");
-				return new ReceiptOcrFailedException();
-			});
-
-		var receipt = Optional.ofNullable(image.receipt())
-			.map(ReceiptOcrResponse.ReceiptWrapper::result)
-			.orElseThrow(() -> {
-				log.warn("[OCR FAILED] receipt.result is null");
-				return new ReceiptOcrFailedException();
-			});
-
-		//상호명
-		String storeName = Optional.ofNullable(receipt.storeInfo())
-			.map(ReceiptOcrResponse.StoreInfo::name)
-			.map(ReceiptOcrResponse.TextField::text)
-			.orElseThrow(() -> {
-				log.warn("[OCR FAILED] storeName missing");
-				return new ReceiptOcrFailedException();
-			});
-
-		//총액
-		String totalPrice = Optional.ofNullable(receipt.totalPrice())
-			.map(ReceiptOcrResponse.TotalPrice::price)
-			.map(ReceiptOcrResponse.TextField::text)
-			.orElseThrow(() -> {
-				log.warn("[OCR FAILED] totalPrice missing, paymentInfo={}",
-					receipt.paymentInfo());
-				return new ReceiptOcrFailedException();
-			});
-
-		//결제일
-		LocalDate paymentDate = Optional.ofNullable(receipt.paymentInfo())
-			.map(ReceiptOcrResponse.PaymentInfo::date)
-			.map(ReceiptOcrResponse.TextField::text)
-			.map(this::parseDate)
-			.orElseThrow(() -> {
-				log.warn("[OCR FAILED] paymentDate missing");
-				return new ReceiptOcrFailedException();
-			});
-
-		//상품 목록
-		List<ReceiptItemDto> items = Optional.ofNullable(receipt.subResults())
-			.orElse(List.of())
-			.stream()
-			.flatMap(sr -> Optional.ofNullable(sr.items()).orElse(List.of()).stream())
-			.map(reviewMapper::toDto)
-			.toList();
-		log.info("[OCR ITEMS] count={}", items.size());
-
-		return reviewMapper.toReceiptResultDto(storeName, totalPrice, paymentDate, items);
-	}
-
-	private LocalDate parseDate(String text) {
-		if (text == null || text.isBlank())
-			return null;
-		// 숫자가 아닌 문자 제거
-		String normalized = text.replaceAll("[^0-9]", "");
-		try {
-			return LocalDate.parse(normalized, DateTimeFormatter.BASIC_ISO_DATE);
-		} catch (DateTimeParseException e) {
-			log.warn("[OCR DATE PARSE FAILED] text={}", text, e);
-			throw new ReceiptDateParseException();
-		}
-	}
-}
+//
+// @Service
+// @Slf4j
+// @RequiredArgsConstructor
+// public class OcrService {
+//
+// 	private final ClovaOcrClient clovaOcrClient;
+// 	private final ObjectMapper objectMapper;
+// 	private final ReviewService reviewService;
+// 	private final ReviewMapper reviewMapper;
+// 	private final PlaceRepository placeRepository;
+//
+// 	public ReviewPartnerResponse processReceipt(MultipartFile file, Long userId, Long placeId) {
+// 		Place place = placeRepository.findById(placeId)
+// 			.orElseThrow(PlaceInfoNotFoundException::new);
+//
+// 		//MultipartFIle -> byte[]
+// 		byte[] imageBytes;
+// 		try {
+// 			imageBytes = file.getBytes();
+// 		} catch (IOException e) {
+// 			throw new ReceiptFileConvertException();
+// 		}
+//
+// 		//ocr
+// 		String rawResponse = clovaOcrClient.requestReceiptOcr(imageBytes, file.getOriginalFilename());
+// 		log.debug("[OCR RAW RESPONSE] {}", rawResponse);
+//
+// 		ReceiptOcrResponse ocrResponse = parse(rawResponse);
+// 		ReceiptResultDto result = extractReceiptResult(ocrResponse);
+// 		log.info("영수증 ocr 인식 결과:{}", result);
+//
+// 		return reviewService.findPartnership(place.getPlaceId(), result, userId);
+// 	}
+//
+// 	private ReceiptOcrResponse parse(String json) {
+// 		try {
+// 			log.debug("[OCR PARSE INPUT] {}", json);
+// 			return objectMapper.readValue(json, ReceiptOcrResponse.class);
+// 		} catch (Exception e) {
+// 			log.error("[OCR PARSE FAILED] raw={}", json, e);
+// 			throw new ReceiptOcrFailedException();
+// 		}
+// 	}
+//
+// 	private ReceiptResultDto extractReceiptResult(ReceiptOcrResponse response) {
+// 		log.info("[OCR RESPONSE] images size={}",
+// 			response.images() != null ? response.images().size() : null);
+//
+// 		var images = Optional.ofNullable(response.images()).orElse(List.of());
+// 		var image = images.stream()
+// 			.findFirst()
+// 			.orElseThrow(() -> {
+// 				log.warn("[OCR FAILED] images empty");
+// 				return new ReceiptOcrFailedException();
+// 			});
+//
+// 		var receipt = Optional.ofNullable(image.receipt())
+// 			.map(ReceiptOcrResponse.ReceiptWrapper::result)
+// 			.orElseThrow(() -> {
+// 				log.warn("[OCR FAILED] receipt.result is null");
+// 				return new ReceiptOcrFailedException();
+// 			});
+//
+// 		//상호명
+// 		String storeName = Optional.ofNullable(receipt.storeInfo())
+// 			.map(ReceiptOcrResponse.StoreInfo::name)
+// 			.map(ReceiptOcrResponse.TextField::text)
+// 			.orElseThrow(() -> {
+// 				log.warn("[OCR FAILED] storeName missing");
+// 				return new ReceiptOcrFailedException();
+// 			});
+//
+// 		//총액
+// 		String totalPrice = Optional.ofNullable(receipt.totalPrice())
+// 			.map(ReceiptOcrResponse.TotalPrice::price)
+// 			.map(ReceiptOcrResponse.TextField::text)
+// 			.orElseThrow(() -> {
+// 				log.warn("[OCR FAILED] totalPrice missing, paymentInfo={}",
+// 					receipt.paymentInfo());
+// 				return new ReceiptOcrFailedException();
+// 			});
+//
+// 		//결제일
+// 		LocalDate paymentDate = Optional.ofNullable(receipt.paymentInfo())
+// 			.map(ReceiptOcrResponse.PaymentInfo::date)
+// 			.map(ReceiptOcrResponse.TextField::text)
+// 			.map(this::parseDate)
+// 			.orElseThrow(() -> {
+// 				log.warn("[OCR FAILED] paymentDate missing");
+// 				return new ReceiptOcrFailedException();
+// 			});
+//
+// 		//상품 목록
+// 		List<ReceiptItemDto> items = Optional.ofNullable(receipt.subResults())
+// 			.orElse(List.of())
+// 			.stream()
+// 			.flatMap(sr -> Optional.ofNullable(sr.items()).orElse(List.of()).stream())
+// 			.map(reviewMapper::toDto)
+// 			.toList();
+// 		log.info("[OCR ITEMS] count={}", items.size());
+//
+// 		return reviewMapper.toReceiptResultDto(storeName, totalPrice, paymentDate, items);
+// 	}
+//
+// 	private LocalDate parseDate(String text) {
+// 		if (text == null || text.isBlank())
+// 			return null;
+// 		// 숫자가 아닌 문자 제거
+// 		String normalized = text.replaceAll("[^0-9]", "");
+// 		try {
+// 			return LocalDate.parse(normalized, DateTimeFormatter.BASIC_ISO_DATE);
+// 		} catch (DateTimeParseException e) {
+// 			log.warn("[OCR DATE PARSE FAILED] text={}", text, e);
+// 			throw new ReceiptDateParseException();
+// 		}
+// 	}
+// }

--- a/src/main/java/com/campus/campus/domain/review/infrastructure/ClovaOcrClient.java
+++ b/src/main/java/com/campus/campus/domain/review/infrastructure/ClovaOcrClient.java
@@ -1,74 +1,74 @@
-package com.campus.campus.domain.review.infrastructure;
-
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestClient;
-
-import com.campus.campus.domain.review.application.exception.ReceiptImageFormatException;
-
-import lombok.RequiredArgsConstructor;
-
-@Component
-@RequiredArgsConstructor
-public class ClovaOcrClient {
-
-	private final RestClient clovaOcrRestClient;
-
-	@Value("${clova.ocr.invoke-url}")
-	private String invokeUrl;
-
-	@Value("${clova.ocr.secret-key}")
-	private String secretKey;
-
-	public String requestReceiptOcr(byte[] imageBytes, String originalFilename) {
-		//이미지->Base64
-		String base64Image = Base64.getEncoder().encodeToString(imageBytes);
-		String format = extractFormat(originalFilename);
-
-		//json body 구성
-		Map<String, Object> image = new HashMap<>();
-		image.put("format", format);
-		image.put("data", base64Image);
-		image.put("name", "receipt_test2");
-
-		//message 파트
-		Map<String, Object> body = new HashMap<>();
-		body.put("version", "V2");
-		body.put("requestId", UUID.randomUUID().toString());
-		body.put("timestamp", System.currentTimeMillis());
-		body.put("images", List.of(image));
-
-		return clovaOcrRestClient.post()
-			.uri(invokeUrl)
-			.header("X-OCR-SECRET", secretKey)
-			.contentType(MediaType.APPLICATION_JSON)
-			.body(body)
-			.retrieve() // 응답 받기 시작
-			.body(String.class);
-	}
-
-	private String extractFormat(String originalFilename) {
-		if (originalFilename == null) {
-			throw new ReceiptImageFormatException();
-		}
-
-		String lower = originalFilename.toLowerCase();
-
-		if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) {
-			return "jpg";
-		}
-
-		if (lower.endsWith(".png")) {
-			return "png";
-		}
-
-		throw new ReceiptImageFormatException();
-	}
-}
+// package com.campus.campus.domain.review.infrastructure;
+//
+// import java.util.Base64;
+// import java.util.HashMap;
+// import java.util.List;
+// import java.util.Map;
+// import java.util.UUID;
+//
+// import org.springframework.beans.factory.annotation.Value;
+// import org.springframework.http.MediaType;
+// import org.springframework.stereotype.Component;
+// import org.springframework.web.client.RestClient;
+//
+// import com.campus.campus.domain.review.application.exception.ReceiptImageFormatException;
+//
+// import lombok.RequiredArgsConstructor;
+//
+// @Component
+// @RequiredArgsConstructor
+// public class ClovaOcrClient {
+//
+// 	private final RestClient clovaOcrRestClient;
+//
+// 	@Value("${clova.ocr.invoke-url}")
+// 	private String invokeUrl;
+//
+// 	@Value("${clova.ocr.secret-key}")
+// 	private String secretKey;
+//
+// 	public String requestReceiptOcr(byte[] imageBytes, String originalFilename) {
+// 		//이미지->Base64
+// 		String base64Image = Base64.getEncoder().encodeToString(imageBytes);
+// 		String format = extractFormat(originalFilename);
+//
+// 		//json body 구성
+// 		Map<String, Object> image = new HashMap<>();
+// 		image.put("format", format);
+// 		image.put("data", base64Image);
+// 		image.put("name", "receipt_test2");
+//
+// 		//message 파트
+// 		Map<String, Object> body = new HashMap<>();
+// 		body.put("version", "V2");
+// 		body.put("requestId", UUID.randomUUID().toString());
+// 		body.put("timestamp", System.currentTimeMillis());
+// 		body.put("images", List.of(image));
+//
+// 		return clovaOcrRestClient.post()
+// 			.uri(invokeUrl)
+// 			.header("X-OCR-SECRET", secretKey)
+// 			.contentType(MediaType.APPLICATION_JSON)
+// 			.body(body)
+// 			.retrieve() // 응답 받기 시작
+// 			.body(String.class);
+// 	}
+//
+// 	private String extractFormat(String originalFilename) {
+// 		if (originalFilename == null) {
+// 			throw new ReceiptImageFormatException();
+// 		}
+//
+// 		String lower = originalFilename.toLowerCase();
+//
+// 		if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) {
+// 			return "jpg";
+// 		}
+//
+// 		if (lower.endsWith(".png")) {
+// 			return "png";
+// 		}
+//
+// 		throw new ReceiptImageFormatException();
+// 	}
+// }

--- a/src/main/java/com/campus/campus/domain/review/presentation/ReviewController.java
+++ b/src/main/java/com/campus/campus/domain/review/presentation/ReviewController.java
@@ -14,9 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.campus.campus.domain.review.application.dto.request.PartnershipReviewRequest;
 import com.campus.campus.domain.review.application.dto.request.PlaceReviewRequest;
@@ -24,10 +22,8 @@ import com.campus.campus.domain.review.application.dto.response.CursorPageReview
 import com.campus.campus.domain.review.application.dto.response.MyReviewResponse;
 import com.campus.campus.domain.review.application.dto.response.PlaceReviewRankResponse;
 import com.campus.campus.domain.review.application.dto.response.ReviewCreateResponse;
-import com.campus.campus.domain.review.application.dto.response.ReviewPartnerResponse;
 import com.campus.campus.domain.review.application.dto.response.ReviewResponse;
 import com.campus.campus.domain.review.application.dto.response.WriteReviewResponse;
-import com.campus.campus.domain.review.application.service.OcrService;
 import com.campus.campus.domain.review.application.service.ReviewService;
 import com.campus.campus.global.annotation.CurrentUserId;
 import com.campus.campus.global.common.response.CommonResponse;
@@ -43,7 +39,7 @@ import lombok.RequiredArgsConstructor;
 public class ReviewController {
 
 	private final ReviewService reviewService;
-	private final OcrService ocrService;
+	// private final OcrService ocrService;
 
 	@PostMapping
 	@Operation(
@@ -112,25 +108,25 @@ public class ReviewController {
 		value = "/receipt-ocr",
 		consumes = MediaType.MULTIPART_FORM_DATA_VALUE
 	)
-	@Operation(
-		summary = "영수증 OCR을 통한 제휴 매장 이용 인증",
-		description = """
-			제휴 매장 리뷰 작성 전, 영수증 OCR을 통해 이용 여부를 인증하는 API입니다.
-			
-			- 제휴 매장 리뷰 작성 시 반드시 먼저 호출해야 합니다.
-			- OCR 인증이 성공적으로 완료된 후 리뷰 작성 API를 호출해주세요.
-			- 리뷰 작성 시 isVerified = true 값을 함께 전달해야 합니다.
-			- 제휴 매장이 아닌 경우에는 본 API를 호출하지 않고,
-			  리뷰 작성 API를 바로 호출하시면 됩니다.
-			"""
-	)
-	public CommonResponse<ReviewPartnerResponse> upload(
-		@RequestPart("file") MultipartFile file,
-		@RequestParam("placeId") Long placeId,
-		@CurrentUserId Long userId
-	) {
-		return CommonResponse.success(ReviewResponseCode.OCR_SUCCESS, ocrService.processReceipt(file, userId, placeId));
-	}
+	// @Operation(
+	// 	summary = "영수증 OCR을 통한 제휴 매장 이용 인증",
+	// 	description = """
+	// 		제휴 매장 리뷰 작성 전, 영수증 OCR을 통해 이용 여부를 인증하는 API입니다.
+	//
+	// 		- 제휴 매장 리뷰 작성 시 반드시 먼저 호출해야 합니다.
+	// 		- OCR 인증이 성공적으로 완료된 후 리뷰 작성 API를 호출해주세요.
+	// 		- 리뷰 작성 시 isVerified = true 값을 함께 전달해야 합니다.
+	// 		- 제휴 매장이 아닌 경우에는 본 API를 호출하지 않고,
+	// 		  리뷰 작성 API를 바로 호출하시면 됩니다.
+	// 		"""
+	// )
+	// public CommonResponse<ReviewPartnerResponse> upload(
+	// 	@RequestPart("file") MultipartFile file,
+	// 	@RequestParam("placeId") Long placeId,
+	// 	@CurrentUserId Long userId
+	// ) {
+	// 	return CommonResponse.success(ReviewResponseCode.OCR_SUCCESS, ocrService.processReceipt(file, userId, placeId));
+	// }
 
 	@GetMapping("/{reviewId}")
 	@Operation(summary = "리뷰 상세 조회")

--- a/src/main/java/com/campus/campus/domain/user/application/exception/CauOnlyException.java
+++ b/src/main/java/com/campus/campus/domain/user/application/exception/CauOnlyException.java
@@ -1,0 +1,9 @@
+package com.campus.campus.domain.user.application.exception;
+
+import com.campus.campus.global.common.exception.ApplicationException;
+
+public class CauOnlyException extends ApplicationException {
+	public CauOnlyException() {
+		super(ErrorCode.CAU_SCHOOL_ONLY);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/user/application/exception/ErrorCode.java
+++ b/src/main/java/com/campus/campus/domain/user/application/exception/ErrorCode.java
@@ -11,11 +11,12 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode implements ErrorCodeInterface {
 	USER_NOT_FOUND(2100, HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
-	USER_NOT_FIRST_LOGIN(2101, HttpStatus.BAD_REQUEST, "최초 로그인한 사용가 아닙니다."),
+	USER_NOT_FIRST_LOGIN(2101, HttpStatus.BAD_REQUEST, "최초 로그인한 사용자가 아닙니다."),
 	NICKNAME_NOT_MATCH(2102, HttpStatus.BAD_REQUEST, "닉네임이 일치하지 않습니다."),
-	USER_SIGNUP_FORBIDDEN_NOW(2103, HttpStatus.FORBIDDEN, "현재 유저 회원가입할 수 없는 계정입니다."),
+	USER_SIGNUP_FORBIDDEN_NOW(2103, HttpStatus.FORBIDDEN, "현재 회원가입할 수 없는 계정입니다."),
 	NICKNAME_ALREADY_EXISTS(2104, HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
-	ACADEMIC_INFO_CANNOT_CHANGE(2105, HttpStatus.BAD_REQUEST, "학적 정보는 6개월에 한번만 변경 가능합니다.");
+	ACADEMIC_INFO_CANNOT_CHANGE(2105, HttpStatus.BAD_REQUEST, "학적 정보는 6개월에 한번만 변경 가능합니다."),
+	CAU_SCHOOL_ONLY(2106, HttpStatus.BAD_REQUEST, "중앙대학교 학생만 가입할 수 있습니다.");
 
 	private final int code;
 	private final HttpStatus status;

--- a/src/main/java/com/campus/campus/domain/user/application/service/UserService.java
+++ b/src/main/java/com/campus/campus/domain/user/application/service/UserService.java
@@ -23,6 +23,7 @@ import com.campus.campus.domain.user.application.dto.response.UserFirstProfileRe
 import com.campus.campus.domain.user.application.dto.response.UserInfoIdsResponse;
 import com.campus.campus.domain.user.application.dto.response.UserInfoResponse;
 import com.campus.campus.domain.user.application.exception.AcademicInfoUpdateRestrictionException;
+import com.campus.campus.domain.user.application.exception.CauOnlyException;
 import com.campus.campus.domain.user.application.exception.NicknameAlreadyExistsException;
 import com.campus.campus.domain.user.application.exception.UserNotFirstLoginException;
 import com.campus.campus.domain.user.application.exception.UserNotFoundException;
@@ -40,6 +41,7 @@ public class UserService {
 	private final SchoolRepository schoolRepository;
 	private final MajorRepository majorRepository;
 	private final UserMapper userMapper;
+	private static final Long CAU_SCHOOL_ID = 285L;
 
 	@Transactional
 	public UserFirstProfileResponse writeUserProfile(Long userId, UserProfileRequest userProfileRequest) {
@@ -48,6 +50,10 @@ public class UserService {
 
 		if (!user.isProfileNotCompleted()) {
 			throw new UserNotFirstLoginException();
+		}
+
+		if (!CAU_SCHOOL_ID.equals(userProfileRequest.schoolId())) {
+			throw new CauOnlyException();
 		}
 
 		School school = schoolRepository.findById(userProfileRequest.schoolId())
@@ -100,6 +106,10 @@ public class UserService {
 			if (LocalDateTime.now().isBefore(nextAvailableDate)) {
 				throw new AcademicInfoUpdateRestrictionException();
 			}
+		}
+
+		if (!CAU_SCHOOL_ID.equals(userAcademicRequest.schoolId())) {
+			throw new CauOnlyException();
 		}
 
 		School school = schoolRepository.findById(userAcademicRequest.schoolId())


### PR DESCRIPTION
## 🔀 변경 내용
- 사용자 학교 이메일 및 학적 정보 중앙대 제한 기능 구현

## ✅ 작업 항목
- [x] 학교 이메일 입력 검증 
- [x] 학적 정보 schoolId 검증
- [x]  리뷰 ocr 임시 주석 처리
- [x] 테스트 완료 여부

## 📸 스크린샷 (선택)
<img width="808" height="351" alt="image" src="https://github.com/user-attachments/assets/bede41d8-94eb-49c9-b02f-a315f3b92f7a" />
<img width="751" height="271" alt="image" src="https://github.com/user-attachments/assets/8731f101-f139-4983-88e2-aa44f139c5ca" />

## 📎 참고 이슈
관련 이슈 번호 #92 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 중앙대학교 학생 전용 접근 제한 강화

* **버그 수정**
  * 이메일 검증 로직 개선 (중앙대학교 도메인 필수)
  * 오류 메시지 텍스트 수정

* **Refactor**
  * 영수증 OCR 기능 비활성화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->