### PR TITLE
Refactor/#94 학생회 타입별 게시글 목록 조회, 72시간 이내 행사 조회 API 통합

### DIFF
--- a/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
@@ -111,7 +111,8 @@ public class StudentCouncilPostForUserService {
 
 	public Page<PostListItemResponse> findPosts(CouncilType councilType, PostCategory category, int page, int size,
 		Long userId, Long excludePostId) {
-		User user = userRepository.findByIdWithAcademicInfo(userId).orElseThrow(UserNotFoundException::new);
+		User user = userRepository.findByIdWithAcademicInfo(userId)
+			.orElseThrow(UserNotFoundException::new);
 
 		Long collegeId = null;
 		Long majorId = null;
@@ -139,74 +140,38 @@ public class StudentCouncilPostForUserService {
 		return mapPostsWithLikes(posts, userId);
 	}
 
-	public Page<PostListItemResponse> findUpcomingSchoolEvents72h(int page, int size, Long userId) {
-		User user = userRepository.findByIdWithAcademicInfo(userId).orElseThrow(UserNotFoundException::new);
+	public Page<PostListItemResponse> findUpcomingEvents72h(CouncilType councilType, int page, int size, Long userId) {
+		User user = userRepository.findByIdWithAcademicInfo(userId)
+			.orElseThrow(UserNotFoundException::new);
+
+		Long collegeId = null;
+		Long majorId = null;
+
+		if (CouncilType.COLLEGE_COUNCIL.equals(councilType)) {
+			if (user.isProfileNotCompleted() || user.getCollege() == null) {
+				throw new CollegeNotSetException();
+			}
+			collegeId = user.getCollege().getCollegeId();
+		}
+
+		if (CouncilType.MAJOR_COUNCIL.equals(councilType)) {
+			if (user.isProfileNotCompleted() || user.getMajor() == null) {
+				throw new MajorNotSetException();
+			}
+			majorId = user.getMajor().getMajorId();
+		}
 
 		Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size, Sort.by(Sort.Direction.ASC, "startDateTime"));
 
 		LocalDateTime now = LocalDateTime.now(KST);
 		LocalDateTime limit = now.plusHours(UPCOMING_HOURS);
 
-		Page<StudentCouncilPost> posts = studentCouncilPostRepository.findUpcomingSchoolEvents(
+		Page<StudentCouncilPost> posts = studentCouncilPostRepository.findUpcomingEvents(
 			user.getSchool().getSchoolId(),
+			councilType,
+			collegeId,
+			majorId,
 			PostCategory.EVENT,
-			CouncilType.SCHOOL_COUNCIL,
-			now,
-			limit,
-			pageable
-		);
-
-		return mapPostsWithLikes(posts, userId);
-	}
-
-	public Page<PostListItemResponse> findUpcomingCollegeEvents72h(int page, int size, Long userId) {
-		User user = userRepository.findByIdWithAcademicInfo(userId).orElseThrow(UserNotFoundException::new);
-
-		if (user.isProfileNotCompleted() || user.getCollege() == null) {
-			throw new CollegeNotSetException();
-		}
-
-		Pageable pageable = PageRequest.of(
-			Math.max(page - 1, 0),
-			size,
-			Sort.by(Sort.Direction.ASC, "startDateTime")
-		);
-
-		LocalDateTime now = LocalDateTime.now(KST);
-		LocalDateTime limit = now.plusHours(UPCOMING_HOURS);
-
-		Page<StudentCouncilPost> posts = studentCouncilPostRepository.findUpcomingCollegeEvents(
-			user.getCollege().getCollegeId(),
-			PostCategory.EVENT,
-			CouncilType.COLLEGE_COUNCIL,
-			now,
-			limit,
-			pageable
-		);
-
-		return mapPostsWithLikes(posts, userId);
-	}
-
-	public Page<PostListItemResponse> findUpcomingMajorEvents72h(int page, int size, Long userId) {
-		User user = userRepository.findByIdWithAcademicInfo(userId).orElseThrow(UserNotFoundException::new);
-
-		if (user.isProfileNotCompleted() || user.getMajor() == null) {
-			throw new MajorNotSetException();
-		}
-
-		Pageable pageable = PageRequest.of(
-			Math.max(page - 1, 0),
-			size,
-			Sort.by(Sort.Direction.ASC, "startDateTime")
-		);
-
-		LocalDateTime now = LocalDateTime.now(KST);
-		LocalDateTime limit = now.plusHours(UPCOMING_HOURS);
-
-		Page<StudentCouncilPost> posts = studentCouncilPostRepository.findUpcomingMajorEvents(
-			user.getMajor().getMajorId(),
-			PostCategory.EVENT,
-			CouncilType.MAJOR_COUNCIL,
 			now,
 			limit,
 			pageable

--- a/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
@@ -109,48 +109,32 @@ public class StudentCouncilPostForUserService {
 		return studentCouncilPostMapper.toGetPostForUserResponse(post, imageUrls, userId, isLiked);
 	}
 
-	public Page<PostListItemResponse> findSchoolPosts(PostCategory category, int page, int size, Long userId,
-		Long excludePostId) {
+	public Page<PostListItemResponse> findPosts(CouncilType councilType, PostCategory category, int page, int size,
+		Long userId, Long excludePostId) {
 		User user = userRepository.findByIdWithAcademicInfo(userId).orElseThrow(UserNotFoundException::new);
 
-		Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size, Sort.by(Sort.Direction.DESC, "startDateTime"));
+		Long collegeId = null;
+		Long majorId = null;
 
-		Page<StudentCouncilPost> posts = studentCouncilPostRepository
-			.findBySchoolId(user.getSchool().getSchoolId(), category, CouncilType.SCHOOL_COUNCIL, excludePostId,
-				pageable);
+		if (CouncilType.COLLEGE_COUNCIL.equals(councilType)) {
+			if (user.isProfileNotCompleted() || user.getCollege() == null) {
+				throw new CollegeNotSetException();
+			}
+			collegeId = user.getCollege().getCollegeId();
+		}
 
-		return mapPostsWithLikes(posts, userId);
-	}
-
-	public Page<PostListItemResponse> findCollegePosts(PostCategory category, int page, int size, Long userId,
-		Long excludePostId) {
-		User user = userRepository.findByIdWithAcademicInfo(userId).orElseThrow(UserNotFoundException::new);
-
-		if (user.isProfileNotCompleted() || user.getCollege() == null) {
-			throw new CollegeNotSetException();
+		if (CouncilType.MAJOR_COUNCIL.equals(councilType)) {
+			if (user.isProfileNotCompleted() || user.getMajor() == null) {
+				throw new MajorNotSetException();
+			}
+			majorId = user.getMajor().getMajorId();
 		}
 
 		Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size, Sort.by(Sort.Direction.DESC, "startDateTime"));
 
 		Page<StudentCouncilPost> posts = studentCouncilPostRepository
-			.findByCollegeId(user.getCollege().getCollegeId(), category, CouncilType.COLLEGE_COUNCIL, excludePostId,
+			.findByCouncilType(user.getSchool().getSchoolId(), councilType, collegeId, majorId, category, excludePostId,
 				pageable);
-
-		return mapPostsWithLikes(posts, userId);
-	}
-
-	public Page<PostListItemResponse> findMajorPosts(PostCategory category, int page, int size, Long userId,
-		Long excludePostId) {
-		User user = userRepository.findByIdWithAcademicInfo(userId).orElseThrow(UserNotFoundException::new);
-
-		if (user.isProfileNotCompleted() || user.getMajor() == null) {
-			throw new MajorNotSetException();
-		}
-
-		Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size, Sort.by(Sort.Direction.DESC, "startDateTime"));
-
-		Page<StudentCouncilPost> posts = studentCouncilPostRepository
-			.findByMajorId(user.getMajor().getMajorId(), category, CouncilType.MAJOR_COUNCIL, excludePostId, pageable);
 
 		return mapPostsWithLikes(posts, userId);
 	}

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/repository/StudentCouncilPostRepository.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/repository/StudentCouncilPostRepository.java
@@ -121,60 +121,23 @@ public interface StudentCouncilPostRepository extends JpaRepository<StudentCounc
 	@Query("""
 		SELECT p FROM StudentCouncilPost p
 		JOIN p.writer w
-		JOIN w.school s
-		WHERE w.councilType = :councilType
-		  AND s.schoolId = :schoolId
+		LEFT JOIN w.college c
+		LEFT JOIN w.major m
+		WHERE w.school.schoolId = :schoolId
+		  AND w.councilType = :councilType
+		  AND (:collegeId IS NULL OR c.collegeId = :collegeId)
+		  AND (:majorId IS NULL OR m.majorId = :majorId)
 		  AND p.category = :category
 		  AND p.startDateTime BETWEEN :now AND :limit
 		  AND w.deletedAt IS NULL
 		ORDER BY p.startDateTime ASC
 		""")
-	Page<StudentCouncilPost> findUpcomingSchoolEvents(
+	Page<StudentCouncilPost> findUpcomingEvents(
 		@Param("schoolId") Long schoolId,
-		@Param("category") PostCategory category,
 		@Param("councilType") CouncilType councilType,
-		@Param("now") LocalDateTime now,
-		@Param("limit") LocalDateTime limit,
-		Pageable pageable
-	);
-
-	@EntityGraph(attributePaths = {"writer", "writer.school", "writer.college", "writer.major"})
-	@Query("""
-		SELECT p FROM StudentCouncilPost p
-		JOIN p.writer w
-		JOIN w.college c
-		WHERE w.councilType = :councilType
-		  AND c.collegeId = :collegeId
-		  AND p.category = :category
-		  AND p.startDateTime BETWEEN :now AND :limit
-		  AND w.deletedAt IS NULL
-		ORDER BY p.startDateTime ASC
-		""")
-	Page<StudentCouncilPost> findUpcomingCollegeEvents(
 		@Param("collegeId") Long collegeId,
-		@Param("category") PostCategory category,
-		@Param("councilType") CouncilType councilType,
-		@Param("now") LocalDateTime now,
-		@Param("limit") LocalDateTime limit,
-		Pageable pageable
-	);
-
-	@EntityGraph(attributePaths = {"writer", "writer.school", "writer.college", "writer.major"})
-	@Query("""
-		SELECT p FROM StudentCouncilPost p
-		JOIN p.writer w
-		JOIN w.major m
-		WHERE w.councilType = :councilType
-		  AND m.majorId = :majorId
-		  AND p.category = :category
-		  AND p.startDateTime BETWEEN :now AND :limit
-		  AND w.deletedAt IS NULL
-		ORDER BY p.startDateTime ASC
-		""")
-	Page<StudentCouncilPost> findUpcomingMajorEvents(
 		@Param("majorId") Long majorId,
 		@Param("category") PostCategory category,
-		@Param("councilType") CouncilType councilType,
 		@Param("now") LocalDateTime now,
 		@Param("limit") LocalDateTime limit,
 		Pageable pageable

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/repository/StudentCouncilPostRepository.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/repository/StudentCouncilPostRepository.java
@@ -95,58 +95,24 @@ public interface StudentCouncilPostRepository extends JpaRepository<StudentCounc
 
 	@EntityGraph(attributePaths = {"writer", "writer.school", "writer.college", "writer.major"})
 	@Query("""
-		
 		SELECT p FROM StudentCouncilPost p
-		      JOIN p.writer w
-		      JOIN w.school s
-		      WHERE w.councilType = :councilType
-		        AND s.schoolId = :schoolId
-		        AND (:category IS NULL OR p.category = :category)
-				AND (:excludePostId IS NULL OR p.id <> :excludePostId)
-		        AND w.deletedAt IS NULL
+		JOIN p.writer w
+		LEFT JOIN w.college c
+		LEFT JOIN w.major m
+		WHERE w.school.schoolId = :schoolId
+		  AND w.councilType = :councilType
+		  AND (:collegeId IS NULL OR c.collegeId = :collegeId)
+		  AND (:majorId IS NULL OR m.majorId = :majorId)
+		  AND (:category IS NULL OR p.category = :category)
+		  AND (:excludePostId IS NULL OR p.id <> :excludePostId)
+		  AND w.deletedAt IS NULL
 		""")
-	Page<StudentCouncilPost> findBySchoolId(
+	Page<StudentCouncilPost> findByCouncilType(
 		@Param("schoolId") Long schoolId,
-		@Param("category") PostCategory category,
 		@Param("councilType") CouncilType councilType,
-		@Param("excludePostId") Long excludePostId,
-		Pageable pageable
-	);
-
-	@EntityGraph(attributePaths = {"writer", "writer.school", "writer.college", "writer.major"})
-	@Query("""
-		SELECT p FROM StudentCouncilPost p
-		JOIN p.writer w
-		JOIN w.college c
-		WHERE w.councilType = :councilType
-		  AND c.collegeId = :collegeId
-		  AND (:category IS NULL OR p.category = :category)
-		  AND (:excludePostId IS NULL OR p.id <> :excludePostId)
-		  AND w.deletedAt IS NULL
-		""")
-	Page<StudentCouncilPost> findByCollegeId(
 		@Param("collegeId") Long collegeId,
-		@Param("category") PostCategory category,
-		@Param("councilType") CouncilType councilType,
-		@Param("excludePostId") Long excludePostId,
-		Pageable pageable
-	);
-
-	@EntityGraph(attributePaths = {"writer", "writer.school", "writer.college", "writer.major"})
-	@Query("""
-		SELECT p FROM StudentCouncilPost p
-		JOIN p.writer w
-		JOIN w.major m
-		WHERE w.councilType = :councilType
-		  AND m.majorId = :majorId
-		  AND (:category IS NULL OR p.category = :category)
-		  AND (:excludePostId IS NULL OR p.id <> :excludePostId)
-		  AND w.deletedAt IS NULL
-		""")
-	Page<StudentCouncilPost> findByMajorId(
 		@Param("majorId") Long majorId,
 		@Param("category") PostCategory category,
-		@Param("councilType") CouncilType councilType,
 		@Param("excludePostId") Long excludePostId,
 		Pageable pageable
 	);

--- a/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostForUserController.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostForUserController.java
@@ -58,94 +58,36 @@ public class StudentCouncilPostForUserController {
 		return CommonResponse.success(StudentCouncilPostResponseCode.POST_LIST_READ_SUCCESS, responses);
 	}
 
-	@GetMapping("/school")
+	@GetMapping
 	@Operation(
-		summary = "학교 학생회 게시글 목록 조회",
+		summary = "학생회 타입별 게시글 목록 조회",
 		description =
-			"현재 로그인한 사용자가 속한 **학교 범위**의 학생회 게시글 목록을 조회합니다.\n\n" +
-				"### ✅ 필터/페이징\n" +
-				"- `category`를 전달하면 해당 카테고리만 조회합니다. (미전달 시 전체)\n" +
-				"- `page`는 1부터 시작합니다.\n" +
-				"- `size`는 한 페이지당 조회 개수입니다.\n\n" +
-				"### ✅ 현재 게시글 제외 조회(상세 하단 '다른 글' 용도)\n" +
-				"- `excludePostId`를 전달하면 해당 게시글 ID를 목록에서 제외하고 조회합니다.\n" +
-				"- 목록 페이지에서는 `excludePostId` 없이 호출하면 됩니다.\n\n" +
-				"### 🔎 예시\n" +
-				"- 목록 조회: `/student-council/posts/school?page=1&size=20`\n" +
-				"- 카테고리 필터: `/student-council/posts/school?category=EVENT&page=1&size=20`\n" +
-				"- 상세 하단 다른 글: `/student-council/posts/school?excludePostId=123&page=1&size=20`"
-	)
-	public CommonResponse<Page<PostListItemResponse>> getSchoolPosts(
-		@RequestParam(required = false) PostCategory category,
-		@RequestParam(defaultValue = "1") int page,
-		@RequestParam(defaultValue = "20") int size,
-		@RequestParam(required = false) Long excludePostId,
-		@CurrentUserId Long userId
-	) {
-		Page<PostListItemResponse> responseDto = postService.findSchoolPosts(category, page, size, userId,
-			excludePostId);
-		return CommonResponse.success(StudentCouncilPostResponseCode.POST_LIST_READ_SUCCESS, responseDto);
-	}
-
-	@GetMapping("/college")
-	@Operation(
-		summary = "단과대 학생회 게시글 목록 조회",
-		description =
-			"현재 로그인한 사용자가 속한 **단과대(College) 범위**의 학생회 게시글 목록을 조회합니다.\n\n" +
+			"현재 로그인한 사용자가 속한 학생회 범위의 게시글 목록을 **타입별로** 조회합니다.\n\n" +
+				"### ✅ councilType (필수)\n" +
+				"- `SCHOOL_COUNCIL` : 학교 학생회\n" +
+				"- `COLLEGE_COUNCIL` : 단과대 학생회 (단과대 정보 미설정 시 예외)\n" +
+				"- `MAJOR_COUNCIL` : 전공 학생회 (전공 정보 미설정 시 예외)\n\n" +
 				"### ✅ 필터/페이징\n" +
 				"- `category`를 전달하면 해당 카테고리만 조회합니다. (미전달 시 전체)\n" +
 				"- `page`는 1부터 시작합니다.\n" +
 				"- `size`는 한 페이지당 조회 개수입니다.\n\n" +
 				"### ✅ 현재 게시글 제외 조회(상세 하단 '다른 글' 용도)\n" +
 				"- `excludePostId`를 전달하면 해당 게시글 ID를 목록에서 제외하고 조회합니다.\n\n" +
-				"### ⚠️ 예외\n" +
-				"- 사용자가 프로필(학교/단과대 정보)을 완료하지 않았거나 단과대가 설정되어 있지 않으면 예외가 발생할 수 있습니다.\n\n" +
 				"### 🔎 예시\n" +
-				"- 목록 조회: `/student-council/posts/college?page=1&size=20`\n" +
-				"- 카테고리 필터: `/student-council/posts/college?category=PARTNERSHIP&page=1&size=20`\n" +
-				"- 상세 하단 다른 글: `/student-council/posts/college?excludePostId=123&page=1&size=20`"
+				"- 학교 목록: `?councilType=SCHOOL_COUNCIL&page=1&size=20`\n" +
+				"- 단과대 카테고리 필터: `?councilType=COLLEGE_COUNCIL&category=PARTNERSHIP&page=1&size=20`\n" +
+				"- 상세 하단 다른 글: `?councilType=MAJOR_COUNCIL&excludePostId=123&page=1&size=20`"
 	)
-	public CommonResponse<Page<PostListItemResponse>> getCollegePosts(
+	public CommonResponse<Page<PostListItemResponse>> getPosts(
+		@RequestParam CouncilType councilType,
 		@RequestParam(required = false) PostCategory category,
 		@RequestParam(defaultValue = "1") int page,
 		@RequestParam(defaultValue = "20") int size,
 		@RequestParam(required = false) Long excludePostId,
 		@CurrentUserId Long userId
 	) {
-		Page<PostListItemResponse> responseDto = postService.findCollegePosts(category, page, size, userId,
+		Page<PostListItemResponse> responseDto = postService.findPosts(councilType, category, page, size, userId,
 			excludePostId);
-
-		return CommonResponse.success(StudentCouncilPostResponseCode.POST_LIST_READ_SUCCESS, responseDto);
-	}
-
-	@GetMapping("/major")
-	@Operation(
-		summary = "전공 학생회 게시글 목록 조회",
-		description =
-			"현재 로그인한 사용자가 속한 **전공(Major) 범위**의 학생회 게시글 목록을 조회합니다.\n\n" +
-				"### ✅ 필터/페이징\n" +
-				"- `category`를 전달하면 해당 카테고리만 조회합니다. (미전달 시 전체)\n" +
-				"- `page`는 1부터 시작합니다.\n" +
-				"- `size`는 한 페이지당 조회 개수입니다.\n\n" +
-				"### ✅ 현재 게시글 제외 조회(상세 하단 '다른 글' 용도)\n" +
-				"- `excludePostId`를 전달하면 해당 게시글 ID를 목록에서 제외하고 조회합니다.\n\n" +
-				"### ⚠️ 예외\n" +
-				"- 사용자가 프로필(학교/전공 정보)을 완료하지 않았거나 전공이 설정되어 있지 않으면 예외가 발생할 수 있습니다.\n\n" +
-				"### 🔎 예시\n" +
-				"- 목록 조회: `/student-council/posts/major?page=1&size=20`\n" +
-				"- 카테고리 필터: `/student-council/posts/major?category=EVENT&page=1&size=20`\n" +
-				"- 상세 하단 다른 글: `/student-council/posts/major?excludePostId=123&page=1&size=20`"
-	)
-	public CommonResponse<Page<PostListItemResponse>> getMajorPosts(
-		@RequestParam(required = false) PostCategory category,
-		@RequestParam(defaultValue = "1") int page,
-		@RequestParam(defaultValue = "20") int size,
-		@RequestParam(required = false) Long excludePostId,
-		@CurrentUserId Long userId
-	) {
-		Page<PostListItemResponse> responseDto = postService.findMajorPosts(category, page, size, userId,
-			excludePostId);
-
 		return CommonResponse.success(StudentCouncilPostResponseCode.POST_LIST_READ_SUCCESS, responseDto);
 	}
 

--- a/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostForUserController.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostForUserController.java
@@ -102,45 +102,15 @@ public class StudentCouncilPostForUserController {
 		return CommonResponse.success(StudentCouncilPostResponseCode.POST_READ_SUCCESS, responseDto);
 	}
 
-	@GetMapping("/school/events/upcoming")
-	@Operation(
-		summary = "학교 범위 72시간 이내 행사 조회",
-		description = "사용자의 학교 범위에서 현재 시각 기준 72시간 이내에 시작하는 행사(EVENT) 게시글을 조회합니다. (startDateTime 기준)"
-	)
-	public CommonResponse<Page<PostListItemResponse>> getUpcomingSchoolEvents(
+	@GetMapping("/events/upcoming")
+	@Operation(summary = "학생회 타입별 72시간 이내 행사 조회")
+	public CommonResponse<Page<PostListItemResponse>> getUpcomingEvents(
+		@RequestParam CouncilType councilType,
 		@RequestParam(defaultValue = "1") int page,
 		@RequestParam(defaultValue = "3") int size,
 		@CurrentUserId Long userId
 	) {
-		Page<PostListItemResponse> responseDto = postService.findUpcomingSchoolEvents72h(page, size, userId);
-		return CommonResponse.success(StudentCouncilPostResponseCode.POST_LIST_READ_SUCCESS, responseDto);
-	}
-
-	@GetMapping("/college/events/upcoming")
-	@Operation(
-		summary = "단과대 범위 72시간 이내 행사 조회",
-		description = "사용자의 단과대 범위에서 현재 시각 기준 72시간 이내에 시작하는 행사(EVENT) 게시글을 조회합니다. (startDateTime 기준)"
-	)
-	public CommonResponse<Page<PostListItemResponse>> getUpcomingCollegeEvents(
-		@RequestParam(defaultValue = "1") int page,
-		@RequestParam(defaultValue = "3") int size,
-		@CurrentUserId Long userId
-	) {
-		Page<PostListItemResponse> responseDto = postService.findUpcomingCollegeEvents72h(page, size, userId);
-		return CommonResponse.success(StudentCouncilPostResponseCode.POST_LIST_READ_SUCCESS, responseDto);
-	}
-
-	@GetMapping("/major/events/upcoming")
-	@Operation(
-		summary = "학과 범위 72시간 이내 행사 조회",
-		description = "사용자의 학과 범위에서 현재 시각 기준 72시간 이내에 시작하는 행사(EVENT) 게시글을 조회합니다. (startDateTime 기준)"
-	)
-	public CommonResponse<Page<PostListItemResponse>> getUpcomingMajorEvents(
-		@RequestParam(defaultValue = "1") int page,
-		@RequestParam(defaultValue = "3") int size,
-		@CurrentUserId Long userId
-	) {
-		Page<PostListItemResponse> responseDto = postService.findUpcomingMajorEvents72h(page, size, userId);
+		Page<PostListItemResponse> responseDto = postService.findUpcomingEvents72h(councilType, page, size, userId);
 		return CommonResponse.success(StudentCouncilPostResponseCode.POST_LIST_READ_SUCCESS, responseDto);
 	}
 


### PR DESCRIPTION
## 🔀 변경 내용
- 학생회 타입별 게시글 목록 조회, 72시간 이내 행사 조회 API 통합했습니다.

## ✅ 작업 항목
- [x] 학생회 타입별 게시글 목록 조회 API를 하나로 통합했습니다.
기존: 총학생회, 단과대, 학과 각각 조회 API 존재
이후: 하나의 API안에서 학생회 타입별 조회
- [x] 72시간 이내 행사 조회 API를 하나로 통합했습니다.
기존: 총학생회, 단과대, 학과 각각 조회 API 존재
이후: 하나의 API안에서 학생회 타입별 조회

## 📸 스크린샷 (선택)
### 학생회 타입별 게시글 목록 조회 API
<img width="1460" height="593" alt="image" src="https://github.com/user-attachments/assets/7283cdc4-a912-43ee-afd3-2100ae7d150a" />


### 학생회 타입별 72시간 이내 행사 조회
<img width="1474" height="589" alt="image" src="https://github.com/user-attachments/assets/d0800684-b619-4351-8fbb-4e37d97fbb6b" />


## 📎 참고 이슈
관련 이슈 번호 #94 