### PR TITLE
feat/#99: 학생회 게시글 검색 기능 구현 및 정확도 가중치 정렬 적용

### DIFF
--- a/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import com.campus.campus.domain.council.domain.entity.CouncilType;
 import com.campus.campus.domain.councilpost.application.dto.response.GetActivePartnershipListForUserResponse;
@@ -109,8 +110,8 @@ public class StudentCouncilPostForUserService {
 		return studentCouncilPostMapper.toGetPostForUserResponse(post, imageUrls, userId, isLiked);
 	}
 
-	public Page<PostListItemResponse> findPosts(CouncilType councilType, PostCategory category, int page, int size,
-		Long userId, Long excludePostId) {
+	public Page<PostListItemResponse> findPosts(CouncilType councilType, PostCategory category, String keyword,
+		int page, int size, Long userId, Long excludePostId) {
 		User user = userRepository.findByIdWithAcademicInfo(userId)
 			.orElseThrow(UserNotFoundException::new);
 
@@ -131,11 +132,15 @@ public class StudentCouncilPostForUserService {
 			majorId = user.getMajor().getMajorId();
 		}
 
-		Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size, Sort.by(Sort.Direction.DESC, "startDateTime"));
+		String cleanKeyword = (StringUtils.hasText(keyword))
+			? keyword.replaceAll("\\s", "")
+			: null;
+
+		Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size);
 
 		Page<StudentCouncilPost> posts = studentCouncilPostRepository
-			.findByCouncilType(user.getSchool().getSchoolId(), councilType, collegeId, majorId, category, excludePostId,
-				pageable);
+			.findPostsByFilters(user.getSchool().getSchoolId(), councilType, collegeId, majorId, category,
+				excludePostId, cleanKeyword, pageable);
 
 		return mapPostsWithLikes(posts, userId);
 	}

--- a/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/service/StudentCouncilPostForUserService.java
@@ -134,6 +134,9 @@ public class StudentCouncilPostForUserService {
 
 		String cleanKeyword = (StringUtils.hasText(keyword))
 			? keyword.replaceAll("\\s", "")
+			.replace("\\", "\\\\")
+			.replace("%", "\\%")
+			.replace("_", "\\_")
 			: null;
 
 		Pageable pageable = PageRequest.of(Math.max(page - 1, 0), size);

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/repository/StudentCouncilPostRepository.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/repository/StudentCouncilPostRepository.java
@@ -97,6 +97,7 @@ public interface StudentCouncilPostRepository extends JpaRepository<StudentCounc
 	@Query("""
 		SELECT p FROM StudentCouncilPost p
 		JOIN p.writer w
+		LEFT JOIN p.place pl
 		LEFT JOIN w.college c
 		LEFT JOIN w.major m
 		WHERE w.school.schoolId = :schoolId
@@ -106,14 +107,27 @@ public interface StudentCouncilPostRepository extends JpaRepository<StudentCounc
 		  AND (:category IS NULL OR p.category = :category)
 		  AND (:excludePostId IS NULL OR p.id <> :excludePostId)
 		  AND w.deletedAt IS NULL
+		  AND (:keyword IS NULL OR :keyword = '' OR (
+				  REPLACE(p.title, ' ', '') LIKE %:keyword%
+				  OR REPLACE(pl.placeName, ' ', '') LIKE %:keyword%
+				  ))
+		 	ORDER BY 
+			(CASE
+				WHEN :keyword IS NULL OR :keyword = '' THEN 3
+				WHEN REPLACE(p.title, ' ', '') LIKE %:keyword% THEN	1
+				WHEN REPLACE(pl.placeName, ' ', '') LIKE %:keyword% THEN 2
+				ELSE 3
+			END) ASC,
+			p.startDateTime ASC
 		""")
-	Page<StudentCouncilPost> findByCouncilType(
+	Page<StudentCouncilPost> findPostsByFilters(
 		@Param("schoolId") Long schoolId,
 		@Param("councilType") CouncilType councilType,
 		@Param("collegeId") Long collegeId,
 		@Param("majorId") Long majorId,
 		@Param("category") PostCategory category,
 		@Param("excludePostId") Long excludePostId,
+		@Param("keyword") String keyword,
 		Pageable pageable
 	);
 

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/repository/StudentCouncilPostRepository.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/repository/StudentCouncilPostRepository.java
@@ -108,14 +108,14 @@ public interface StudentCouncilPostRepository extends JpaRepository<StudentCounc
 		  AND (:excludePostId IS NULL OR p.id <> :excludePostId)
 		  AND w.deletedAt IS NULL
 		  AND (:keyword IS NULL OR :keyword = '' OR (
-		              REPLACE(p.title, ' ', '') LIKE CONCAT('%', :keyword, '%') ESCAPE '\\\\'
-		              OR REPLACE(pl.placeName, ' ', '') LIKE CONCAT('%', :keyword, '%') ESCAPE '\\\\'
+		              REPLACE(p.title, ' ', '') LIKE CONCAT('%', :keyword, '%') ESCAPE '\\'
+		              OR REPLACE(pl.placeName, ' ', '') LIKE CONCAT('%', :keyword, '%') ESCAPE '\\'
 		              ))
 		ORDER BY 
 			(CASE
 				 WHEN :keyword IS NULL OR :keyword = '' THEN 3
-				 WHEN REPLACE(p.title, ' ', '') LIKE CONCAT('%', :keyword, '%') ESCAPE '\\\\' THEN 1
-				 WHEN REPLACE(pl.placeName, ' ', '') LIKE CONCAT('%', :keyword, '%') ESCAPE '\\\\' THEN 2
+				 WHEN REPLACE(p.title, ' ', '') LIKE CONCAT('%', :keyword, '%') ESCAPE '\\' THEN 1
+				 WHEN REPLACE(pl.placeName, ' ', '') LIKE CONCAT('%', :keyword, '%') ESCAPE '\\' THEN 2
 				 ELSE 3
 			END) ASC,
 			p.startDateTime ASC

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/repository/StudentCouncilPostRepository.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/repository/StudentCouncilPostRepository.java
@@ -108,15 +108,15 @@ public interface StudentCouncilPostRepository extends JpaRepository<StudentCounc
 		  AND (:excludePostId IS NULL OR p.id <> :excludePostId)
 		  AND w.deletedAt IS NULL
 		  AND (:keyword IS NULL OR :keyword = '' OR (
-				  REPLACE(p.title, ' ', '') LIKE %:keyword%
-				  OR REPLACE(pl.placeName, ' ', '') LIKE %:keyword%
-				  ))
-		 	ORDER BY 
+		              REPLACE(p.title, ' ', '') LIKE CONCAT('%', :keyword, '%') ESCAPE '\\\\'
+		              OR REPLACE(pl.placeName, ' ', '') LIKE CONCAT('%', :keyword, '%') ESCAPE '\\\\'
+		              ))
+		ORDER BY 
 			(CASE
-				WHEN :keyword IS NULL OR :keyword = '' THEN 3
-				WHEN REPLACE(p.title, ' ', '') LIKE %:keyword% THEN	1
-				WHEN REPLACE(pl.placeName, ' ', '') LIKE %:keyword% THEN 2
-				ELSE 3
+				 WHEN :keyword IS NULL OR :keyword = '' THEN 3
+				 WHEN REPLACE(p.title, ' ', '') LIKE CONCAT('%', :keyword, '%') ESCAPE '\\\\' THEN 1
+				 WHEN REPLACE(pl.placeName, ' ', '') LIKE CONCAT('%', :keyword, '%') ESCAPE '\\\\' THEN 2
+				 ELSE 3
 			END) ASC,
 			p.startDateTime ASC
 		""")

--- a/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostForUserController.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostForUserController.java
@@ -19,7 +19,6 @@ import com.campus.campus.domain.councilpost.application.dto.response.LikePostRes
 import com.campus.campus.domain.councilpost.application.dto.response.PostListItemResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.TodayEventResponse;
 import com.campus.campus.domain.councilpost.application.service.StudentCouncilPostForUserService;
-import com.campus.campus.domain.councilpost.application.service.StudentCouncilPostService;
 import com.campus.campus.domain.councilpost.domain.entity.PostCategory;
 import com.campus.campus.global.annotation.CurrentUserId;
 import com.campus.campus.global.common.response.CommonResponse;
@@ -37,7 +36,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class StudentCouncilPostForUserController {
 	private final StudentCouncilPostForUserService postService;
-	private final StudentCouncilPostService studentCouncilPostService;
 
 	@PostMapping("/{postId}/like")
 	@Operation(summary = "학생회 게시글 좋아요 토글")

--- a/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostForUserController.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostForUserController.java
@@ -14,11 +14,12 @@ import org.springframework.web.bind.annotation.RestController;
 import com.campus.campus.domain.council.domain.entity.CouncilType;
 import com.campus.campus.domain.councilpost.application.dto.response.GetActivePartnershipListForUserResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.GetLikedPostResponse;
+import com.campus.campus.domain.councilpost.application.dto.response.GetPostForUserResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.LikePostResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.PostListItemResponse;
-import com.campus.campus.domain.councilpost.application.dto.response.GetPostForUserResponse;
 import com.campus.campus.domain.councilpost.application.dto.response.TodayEventResponse;
 import com.campus.campus.domain.councilpost.application.service.StudentCouncilPostForUserService;
+import com.campus.campus.domain.councilpost.application.service.StudentCouncilPostService;
 import com.campus.campus.domain.councilpost.domain.entity.PostCategory;
 import com.campus.campus.global.annotation.CurrentUserId;
 import com.campus.campus.global.common.response.CommonResponse;
@@ -36,6 +37,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class StudentCouncilPostForUserController {
 	private final StudentCouncilPostForUserService postService;
+	private final StudentCouncilPostService studentCouncilPostService;
 
 	@PostMapping("/{postId}/like")
 	@Operation(summary = "학생회 게시글 좋아요 토글")
@@ -60,13 +62,18 @@ public class StudentCouncilPostForUserController {
 
 	@GetMapping
 	@Operation(
-		summary = "학생회 타입별 게시글 목록 조회",
+		summary = "학생회 타입별 게시글 목록 조회 및 검색",
 		description =
-			"현재 로그인한 사용자가 속한 학생회 범위의 게시글 목록을 **타입별로** 조회합니다.\n\n" +
+			"현재 로그인한 사용자가 속한 학생회 범위의 게시글 목록을 **타입별로** 조회합니다. keyword를 넣으면 검색어로 작동합니다.\n\n" +
 				"### ✅ councilType (필수)\n" +
 				"- `SCHOOL_COUNCIL` : 학교 학생회\n" +
 				"- `COLLEGE_COUNCIL` : 단과대 학생회 (단과대 정보 미설정 시 예외)\n" +
 				"- `MAJOR_COUNCIL` : 전공 학생회 (전공 정보 미설정 시 예외)\n\n" +
+				"### ✅ 검색 (keyword)\n" +
+				"- `keyword`를 전달하면 해당 단어가 포함된 게시글을 필터링합니다.\n" +
+				"- **제휴 검색 시**: 제목(`title`) 또는 장소(`place`)를 검색합니다.\n" +
+				"- **행사 검색 시**: 행사 제목(`title`) 또는 장소(`place`)를 검색합니다.\n" +
+				"- 키워드를 미전달하거나 빈 값일 경우 전체 목록을 반환합니다.\n\n" +
 				"### ✅ 필터/페이징\n" +
 				"- `category`를 전달하면 해당 카테고리만 조회합니다. (미전달 시 전체)\n" +
 				"- `page`는 1부터 시작합니다.\n" +
@@ -76,18 +83,21 @@ public class StudentCouncilPostForUserController {
 				"### 🔎 예시\n" +
 				"- 학교 목록: `?councilType=SCHOOL_COUNCIL&page=1&size=20`\n" +
 				"- 단과대 카테고리 필터: `?councilType=COLLEGE_COUNCIL&category=PARTNERSHIP&page=1&size=20`\n" +
+				"- 키워드 검색: `?councilType=SCHOOL_COUNCIL&keyword=치킨&page=1&size=20`\n" +
 				"- 상세 하단 다른 글: `?councilType=MAJOR_COUNCIL&excludePostId=123&page=1&size=20`"
 	)
 	public CommonResponse<Page<PostListItemResponse>> getPosts(
 		@RequestParam CouncilType councilType,
 		@RequestParam(required = false) PostCategory category,
+		@RequestParam(required = false) String keyword,
 		@RequestParam(defaultValue = "1") int page,
 		@RequestParam(defaultValue = "20") int size,
 		@RequestParam(required = false) Long excludePostId,
 		@CurrentUserId Long userId
 	) {
-		Page<PostListItemResponse> responseDto = postService.findPosts(councilType, category, page, size, userId,
-			excludePostId);
+		Page<PostListItemResponse> responseDto = postService.findPosts(
+			councilType, category, keyword, page, size, userId, excludePostId
+		);
 		return CommonResponse.success(StudentCouncilPostResponseCode.POST_LIST_READ_SUCCESS, responseDto);
 	}
 

--- a/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/presentation/StudentCouncilPostResponseCode.java
@@ -19,7 +19,8 @@ public enum StudentCouncilPostResponseCode implements ResponseCodeInterface {
 	UPCOMING_SCHOOL_EVENT_LIST_READ_SUCCESS(200, HttpStatus.OK, "학교 72시간 이내 행사 조회에 성공했습니다."),
 	UPCOMING_COLLEGE_EVENT_LIST_READ_SUCCESS(200, HttpStatus.OK, "단과대 72시간 이내 행사 조회에 성공했습니다."),
 	UPCOMING_MAJOR_EVENT_LIST_READ_SUCCESS(200, HttpStatus.OK, "학과 72시간 이내 행사 조회에 성공했습니다."),
-	POST_LIKE_SUCCESS(200, HttpStatus.OK, "게시글 좋아요 처리에 성공했습니다.");
+	POST_LIKE_SUCCESS(200, HttpStatus.OK, "게시글 좋아요 처리에 성공했습니다."),
+	POST_SEARCH_SUCCESS(200, HttpStatus.OK, "게시글 검색에 성공했습니다.");
 
 	private final int code;
 	private final HttpStatus status;


### PR DESCRIPTION
## 🔀 변경 내용
- API 통합 및 고도화: 기존의 단순 게시글 목록 조회 API를 확장하여, 조회와 검색을 하나의 엔드포인트에서 처리할 수 있도록 통합했습니다. 검색어가 없을 때는 기존처럼 전체 조회를, 검색어가 있을 때는 필터링된 검색 결과를 반환합니다.
- 지능형 검색 로직: 사용자가 입력한 검색어의 공백을 제거하고, DB 데이터에서도 공백을 무시하고 비교하는 실시간 검색 기능을 구현했습니다.
- 정확도 기반 가중치 정렬: 검색 시 제목(1순위)과 장소(2순위)의 매칭 여부에 따라 가중치를 부여하여, 단순 최신순이 아닌 유저 의도에 가장 부합하는 결과를 상단에 노출합니다.
- 임박순 정렬 유지: 가중치가 동일하거나 검색어가 없는 경우, 행사나 제휴의 시작일(startDateTime)이 가까운 순서대로 정렬하여 정보의 시의성을 높였습니다.
- N+1 문제 최적화: @EntityGraph를 적용하여 writer, school, college, major 등 연관 데이터를 한 번의 쿼리로 효율적으로 조회합니다.

## ✅ 작업 항목
- [x] 기존 목록 조회 API를 검색 파라미터를 포함한 통합 검색 API로 변경
- [x] StudentCouncilPostRepository: REPLACE 및 CASE WHEN을 활용한 통합 조회/검색 쿼리 작성
- [x] StudentCouncilPostForUserService: 검색 키워드 공백 제거 전처리 및 필터링 로직 구현
- [x] StudentCouncilPostForUserController: 조회와 검색을 동시에 처리하는 통합 엔드포인트 연결
- [x] StudentCouncilPostResponseCode: 필터링 및 검색 예외 상황 대응 응답 코드 추가
- [x] 로컬 환경에서 전체 조회 및 키워드 검색 결과/정렬 순서 테스트 완료

## 📸 스크린샷 (선택)
<img width="686" height="569" alt="image" src="https://github.com/user-attachments/assets/91c188b6-99bc-429c-a311-19fba1ffdc1e" />
<img width="571" height="394" alt="image" src="https://github.com/user-attachments/assets/66fdef69-faf1-4d0c-9ead-310bfe77ea80" />

## 📎 참고 이슈
관련 이슈 번호 #99 

- 현재에는 REPLACE를 이용하여 검색이 진행될 때마다 공백을 제거해서 비교하는 중입니다. 이런 방식이 현재와 같이 데이터가 적을 때에는 괜찮지만, 추후 데이터가 수만건으로 늘어났을 때에는 서버 부하가 커지고, 검색어를 찾는 데 시간이 오래걸린다고 합니다.
- 현재는 데이터가 많지 않기 때문에 REPLACE를 이용하였으나, 이가 문제가 될 때에는 StudentCouncilPost와 Place에 `title_search`, `placeName_search`라는 컬럼을 도입하여 저장 시점부터 검색을 위한 공백 제거 컬럼을 추가해야할 것 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게시글 검색 기능 추가: 키워드로 제목 및 장소명을 검색할 수 있으며, 키워드 관련도가 높은 결과가 우선 노출됩니다.
  * 조회 API에 선택적 키워드 파라미터가 추가되어 클라이언트에서 검색어 전달이 가능합니다.

* **기타**
  * 검색 성공에 대한 응답 코드가 추가되어 명확한 성공 표기가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->