### PR TITLE
feat/#103: 학생/학생회 문의 작성 및 조회 API 구현

### DIFF
--- a/src/main/java/com/campus/campus/domain/inquiry/application/dto/request/InquiryCreateRequest.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/application/dto/request/InquiryCreateRequest.java
@@ -1,0 +1,16 @@
+package com.campus.campus.domain.inquiry.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record InquiryCreateRequest(
+	@NotBlank(message = "제목을 입력해주세요.")
+	@Size(max = 100)
+	String title,
+
+	@NotBlank(message = "내용을 입력해주세요.")
+	@Size(min = 10, message = "내용은 최소 10자 이상 작성해주세요.")
+	@Size(max = 1000)
+	String content
+) {
+}

--- a/src/main/java/com/campus/campus/domain/inquiry/application/dto/response/InquiryCreateResponse.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/application/dto/response/InquiryCreateResponse.java
@@ -9,7 +9,10 @@ public record InquiryCreateResponse(
 	Long id,
 
 	@Schema(description = "작성자 ID", example = "2")
-	Long userId,
+	Long writerId,
+
+	@Schema(description = "작성자 타입", example = "USER || STUDENT_COUNCIL")
+	String writerType,
 
 	@Schema(description = "문의 제목", example = "서비스 문의 드려요")
 	String title,

--- a/src/main/java/com/campus/campus/domain/inquiry/application/dto/response/InquiryCreateResponse.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/application/dto/response/InquiryCreateResponse.java
@@ -1,0 +1,26 @@
+package com.campus.campus.domain.inquiry.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record InquiryCreateResponse(
+	@Schema(description = "문의 ID", example = "1")
+	Long id,
+
+	@Schema(description = "작성자 ID", example = "2")
+	Long userId,
+
+	@Schema(description = "문의 제목", example = "서비스 문의 드려요")
+	String title,
+
+	@Schema(description = "문의 내용", example = "문의 남겨요.")
+	String content,
+
+	@Schema(description = "문의 상태", example = "WAITING")
+	String status,
+
+	@Schema(description = "문의 생성일", example = "2026-02-02T23:59:59")
+	LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/campus/campus/domain/inquiry/application/dto/response/InquiryListItemResponse.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/application/dto/response/InquiryListItemResponse.java
@@ -9,7 +9,10 @@ public record InquiryListItemResponse(
 	Long id,
 
 	@Schema(description = "작성자 ID", example = "2")
-	Long userId,
+	Long writerId,
+
+	@Schema(description = "작성자 타입", example = "USER || STUDENT_COUNCIL")
+	String writerType,
 
 	@Schema(description = "문의 제목", example = "서비스 문의 드려요")
 	String title,

--- a/src/main/java/com/campus/campus/domain/inquiry/application/dto/response/InquiryListItemResponse.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/application/dto/response/InquiryListItemResponse.java
@@ -1,0 +1,32 @@
+package com.campus.campus.domain.inquiry.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record InquiryListItemResponse(
+	@Schema(description = "문의 ID", example = "1")
+	Long id,
+
+	@Schema(description = "작성자 ID", example = "2")
+	Long userId,
+
+	@Schema(description = "문의 제목", example = "서비스 문의 드려요")
+	String title,
+
+	@Schema(description = "문의 내용", example = "문의 남겨요.")
+	String content,
+
+	@Schema(description = "문의 상태", example = "WAITING")
+	String status,
+
+	@Schema(description = "문의 답변", example = "안녕하세요, 캠어스입니다.")
+	String answer,
+
+	@Schema(description = "문의 생성일", example = "2026-02-02T23:59:59")
+	LocalDateTime createdAt,
+
+	@Schema(description = "문의 답변일", example = "2026-02-02T23:59:59")
+	LocalDateTime answeredAt
+) {
+}

--- a/src/main/java/com/campus/campus/domain/inquiry/application/mapper/InquiryMapper.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/application/mapper/InquiryMapper.java
@@ -1,0 +1,34 @@
+package com.campus.campus.domain.inquiry.application.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.campus.campus.domain.inquiry.application.dto.request.InquiryCreateRequest;
+import com.campus.campus.domain.inquiry.application.dto.response.InquiryCreateResponse;
+import com.campus.campus.domain.inquiry.domain.entity.Inquiry;
+import com.campus.campus.domain.user.domain.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class InquiryMapper {
+
+	public Inquiry createInquiry(User writer, InquiryCreateRequest dto) {
+		return Inquiry.builder()
+			.writer(writer)
+			.title(dto.title())
+			.content(dto.content())
+			.build();
+	}
+
+	public InquiryCreateResponse toInquiryCreateResponse(Inquiry inquiry) {
+		return new InquiryCreateResponse(
+			inquiry.getId(),
+			inquiry.getWriter().getId(),
+			inquiry.getTitle(),
+			inquiry.getContent(),
+			inquiry.getStatus().name(),
+			inquiry.getCreatedAt()
+		);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/inquiry/application/mapper/InquiryMapper.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/application/mapper/InquiryMapper.java
@@ -7,6 +7,7 @@ import com.campus.campus.domain.inquiry.application.dto.request.InquiryCreateReq
 import com.campus.campus.domain.inquiry.application.dto.response.InquiryCreateResponse;
 import com.campus.campus.domain.inquiry.application.dto.response.InquiryListItemResponse;
 import com.campus.campus.domain.inquiry.domain.entity.Inquiry;
+import com.campus.campus.domain.inquiry.domain.entity.WriterType;
 import com.campus.campus.domain.user.domain.entity.User;
 
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ public class InquiryMapper {
 	public Inquiry createInquiry(User writer, InquiryCreateRequest dto) {
 		return Inquiry.builder()
 			.writer(writer)
+			.writerType(WriterType.USER)
 			.title(dto.title())
 			.content(dto.content())
 			.build();
@@ -26,6 +28,7 @@ public class InquiryMapper {
 	public Inquiry createInquiry(StudentCouncil council, InquiryCreateRequest dto) {
 		return Inquiry.builder()
 			.studentCouncilWriter(council)
+			.writerType(WriterType.STUDENT_COUNCIL)
 			.title(dto.title())
 			.content(dto.content())
 			.build();

--- a/src/main/java/com/campus/campus/domain/inquiry/application/mapper/InquiryMapper.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/application/mapper/InquiryMapper.java
@@ -2,6 +2,7 @@ package com.campus.campus.domain.inquiry.application.mapper;
 
 import org.springframework.stereotype.Component;
 
+import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.inquiry.application.dto.request.InquiryCreateRequest;
 import com.campus.campus.domain.inquiry.application.dto.response.InquiryCreateResponse;
 import com.campus.campus.domain.inquiry.application.dto.response.InquiryListItemResponse;
@@ -22,10 +23,19 @@ public class InquiryMapper {
 			.build();
 	}
 
+	public Inquiry createInquiry(StudentCouncil council, InquiryCreateRequest dto) {
+		return Inquiry.builder()
+			.studentCouncilWriter(council)
+			.title(dto.title())
+			.content(dto.content())
+			.build();
+	}
+
 	public InquiryCreateResponse toInquiryCreateResponse(Inquiry inquiry) {
 		return new InquiryCreateResponse(
 			inquiry.getId(),
-			inquiry.getWriter().getId(),
+			inquiry.getWriterId(),
+			inquiry.getWriterType(),
 			inquiry.getTitle(),
 			inquiry.getContent(),
 			inquiry.getStatus().name(),
@@ -36,13 +46,14 @@ public class InquiryMapper {
 	public InquiryListItemResponse toInquiryListItemResponse(Inquiry inquiry) {
 		return new InquiryListItemResponse(
 			inquiry.getId(),
-			inquiry.getWriter().getId(),
+			inquiry.getWriterId(),
+			inquiry.getWriterType(),
 			inquiry.getTitle(),
 			inquiry.getContent(),
 			inquiry.getStatus().name(),
 			inquiry.getAnswer(),
 			inquiry.getCreatedAt(),
-			inquiry.getUpdatedAt()
+			inquiry.getAnsweredAt()
 		);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/inquiry/application/mapper/InquiryMapper.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/application/mapper/InquiryMapper.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 
 import com.campus.campus.domain.inquiry.application.dto.request.InquiryCreateRequest;
 import com.campus.campus.domain.inquiry.application.dto.response.InquiryCreateResponse;
+import com.campus.campus.domain.inquiry.application.dto.response.InquiryListItemResponse;
 import com.campus.campus.domain.inquiry.domain.entity.Inquiry;
 import com.campus.campus.domain.user.domain.entity.User;
 
@@ -29,6 +30,19 @@ public class InquiryMapper {
 			inquiry.getContent(),
 			inquiry.getStatus().name(),
 			inquiry.getCreatedAt()
+		);
+	}
+
+	public InquiryListItemResponse toInquiryListItemResponse(Inquiry inquiry) {
+		return new InquiryListItemResponse(
+			inquiry.getId(),
+			inquiry.getWriter().getId(),
+			inquiry.getTitle(),
+			inquiry.getContent(),
+			inquiry.getStatus().name(),
+			inquiry.getAnswer(),
+			inquiry.getCreatedAt(),
+			inquiry.getUpdatedAt()
 		);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/inquiry/application/service/InquiryService.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/application/service/InquiryService.java
@@ -1,0 +1,34 @@
+package com.campus.campus.domain.inquiry.application.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.campus.campus.domain.inquiry.application.dto.request.InquiryCreateRequest;
+import com.campus.campus.domain.inquiry.application.dto.response.InquiryCreateResponse;
+import com.campus.campus.domain.inquiry.application.mapper.InquiryMapper;
+import com.campus.campus.domain.inquiry.domain.entity.Inquiry;
+import com.campus.campus.domain.inquiry.domain.repository.InquiryRepository;
+import com.campus.campus.domain.user.application.exception.UserNotFoundException;
+import com.campus.campus.domain.user.domain.entity.User;
+import com.campus.campus.domain.user.domain.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class InquiryService {
+	private final InquiryRepository inquiryRepository;
+	private final InquiryMapper inquiryMapper;
+	private final UserRepository userRepository;
+
+	public InquiryCreateResponse createInquiry(Long userId, InquiryCreateRequest request) {
+		User writer = userRepository.findByIdAndDeletedAtIsNull(userId)
+			.orElseThrow(UserNotFoundException::new);
+
+		Inquiry inquiry = inquiryMapper.createInquiry(writer, request);
+		Inquiry savedInquiry = inquiryRepository.save(inquiry);
+
+		return inquiryMapper.toInquiryCreateResponse(savedInquiry);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/inquiry/application/service/InquiryService.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/application/service/InquiryService.java
@@ -1,10 +1,13 @@
 package com.campus.campus.domain.inquiry.application.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.campus.campus.domain.inquiry.application.dto.request.InquiryCreateRequest;
 import com.campus.campus.domain.inquiry.application.dto.response.InquiryCreateResponse;
+import com.campus.campus.domain.inquiry.application.dto.response.InquiryListItemResponse;
 import com.campus.campus.domain.inquiry.application.mapper.InquiryMapper;
 import com.campus.campus.domain.inquiry.domain.entity.Inquiry;
 import com.campus.campus.domain.inquiry.domain.repository.InquiryRepository;
@@ -30,5 +33,15 @@ public class InquiryService {
 		Inquiry savedInquiry = inquiryRepository.save(inquiry);
 
 		return inquiryMapper.toInquiryCreateResponse(savedInquiry);
+	}
+
+	@Transactional(readOnly = true)
+	public Page<InquiryListItemResponse> getMyInquiries(Long userId, Pageable pageable) {
+		User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+			.orElseThrow(UserNotFoundException::new);
+
+		Page<Inquiry> inquiries = inquiryRepository.findAllByWriterOrderByCreatedAtDesc(user, pageable);
+
+		return inquiries.map(inquiryMapper::toInquiryListItemResponse);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/inquiry/application/service/StudentCouncilInquiryService.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/application/service/StudentCouncilInquiryService.java
@@ -1,0 +1,50 @@
+package com.campus.campus.domain.inquiry.application.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.campus.campus.domain.council.application.exception.StudentCouncilNotFoundException;
+import com.campus.campus.domain.council.domain.entity.StudentCouncil;
+import com.campus.campus.domain.council.domain.repository.StudentCouncilRepository;
+import com.campus.campus.domain.inquiry.application.dto.request.InquiryCreateRequest;
+import com.campus.campus.domain.inquiry.application.dto.response.InquiryCreateResponse;
+import com.campus.campus.domain.inquiry.application.dto.response.InquiryListItemResponse;
+import com.campus.campus.domain.inquiry.application.mapper.InquiryMapper;
+import com.campus.campus.domain.inquiry.domain.entity.Inquiry;
+import com.campus.campus.domain.inquiry.domain.repository.InquiryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class StudentCouncilInquiryService {
+	private final InquiryRepository inquiryRepository;
+	private final InquiryMapper inquiryMapper;
+	private final StudentCouncilRepository studentCouncilRepository;
+
+	public InquiryCreateResponse createInquiry(Long councilId, InquiryCreateRequest request) {
+		StudentCouncil writer = studentCouncilRepository
+			.findByIdAndManagerApprovedIsTrueAndDeletedAtIsNull(councilId)
+			.orElseThrow(StudentCouncilNotFoundException::new);
+
+		Inquiry inquiry = inquiryMapper.createInquiry(writer, request);
+		Inquiry savedInquiry = inquiryRepository.save(inquiry);
+
+		return inquiryMapper.toInquiryCreateResponse(savedInquiry);
+	}
+
+	@Transactional(readOnly = true)
+	public Page<InquiryListItemResponse> getMyInquiries(Long councilId, Pageable pageable) {
+		StudentCouncil council = studentCouncilRepository
+			.findByIdAndManagerApprovedIsTrueAndDeletedAtIsNull(councilId)
+			.orElseThrow(StudentCouncilNotFoundException::new);
+
+		Page<Inquiry> inquiries = inquiryRepository.findAllByStudentCouncilWriterOrderByCreatedAtDesc(council,
+			pageable);
+
+		return inquiries.map(inquiryMapper::toInquiryListItemResponse);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/inquiry/domain/entity/Inquiry.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/domain/entity/Inquiry.java
@@ -2,6 +2,7 @@ package com.campus.campus.domain.inquiry.domain.entity;
 
 import java.time.LocalDateTime;
 
+import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.user.domain.entity.User;
 import com.campus.campus.global.entity.BaseEntity;
 
@@ -38,6 +39,13 @@ public class Inquiry extends BaseEntity {
 	@JoinColumn(name = "user_id")
 	private User writer;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "student_council_id")
+	private StudentCouncil studentCouncilWriter;
+
+	@Enumerated(EnumType.STRING)
+	private WriterType writerType;
+
 	private String title;
 
 	@Column(columnDefinition = "TEXT")
@@ -51,6 +59,20 @@ public class Inquiry extends BaseEntity {
 	private String answer;
 
 	private LocalDateTime answeredAt;
+
+	public Long getWriterId() {
+		if (this.writer != null) {
+			return this.writer.getId();
+		}
+		if (this.studentCouncilWriter != null) {
+			return this.studentCouncilWriter.getId();
+		}
+		return null;
+	}
+
+	public String getWriterType() {
+		return (this.writer != null) ? "USER" : "STUDENT_COUNCIL";
+	}
 
 	public void updateAnswer(String answer) {
 		this.answer = answer;

--- a/src/main/java/com/campus/campus/domain/inquiry/domain/entity/Inquiry.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/domain/entity/Inquiry.java
@@ -1,0 +1,60 @@
+package com.campus.campus.domain.inquiry.domain.entity;
+
+import java.time.LocalDateTime;
+
+import com.campus.campus.domain.user.domain.entity.User;
+import com.campus.campus.global.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "inquiry")
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Inquiry extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User writer;
+
+	private String title;
+
+	@Column(columnDefinition = "TEXT")
+	private String content;
+
+	@Builder.Default
+	@Enumerated(EnumType.STRING)
+	private InquiryStatus status = InquiryStatus.WAITING;
+
+	@Column(columnDefinition = "TEXT")
+	private String answer;
+
+	private LocalDateTime answeredAt;
+
+	public void updateAnswer(String answer) {
+		this.answer = answer;
+		this.status = InquiryStatus.COMPLETED;
+		this.answeredAt = LocalDateTime.now();
+	}
+}

--- a/src/main/java/com/campus/campus/domain/inquiry/domain/entity/Inquiry.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/domain/entity/Inquiry.java
@@ -71,7 +71,7 @@ public class Inquiry extends BaseEntity {
 	}
 
 	public String getWriterType() {
-		return (this.writer != null) ? "USER" : "STUDENT_COUNCIL";
+		return (this.writer != null) ? this.writerType.name() : null;
 	}
 
 	public void updateAnswer(String answer) {

--- a/src/main/java/com/campus/campus/domain/inquiry/domain/entity/InquiryStatus.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/domain/entity/InquiryStatus.java
@@ -1,0 +1,6 @@
+package com.campus.campus.domain.inquiry.domain.entity;
+
+public enum InquiryStatus {
+	WAITING,
+	COMPLETED
+}

--- a/src/main/java/com/campus/campus/domain/inquiry/domain/entity/WriterType.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/domain/entity/WriterType.java
@@ -1,0 +1,6 @@
+package com.campus.campus.domain.inquiry.domain.entity;
+
+public enum WriterType {
+	USER,
+	STUDENT_COUNCIL
+}

--- a/src/main/java/com/campus/campus/domain/inquiry/domain/repository/InquiryRepository.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/domain/repository/InquiryRepository.java
@@ -5,10 +5,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.inquiry.domain.entity.Inquiry;
 import com.campus.campus.domain.user.domain.entity.User;
 
 @Repository
 public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
 	Page<Inquiry> findAllByWriterOrderByCreatedAtDesc(User writer, Pageable pageable);
+
+	Page<Inquiry> findAllByStudentCouncilWriterOrderByCreatedAtDesc(StudentCouncil council, Pageable pageable);
 }

--- a/src/main/java/com/campus/campus/domain/inquiry/domain/repository/InquiryRepository.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/domain/repository/InquiryRepository.java
@@ -1,10 +1,14 @@
 package com.campus.campus.domain.inquiry.domain.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.campus.campus.domain.inquiry.domain.entity.Inquiry;
+import com.campus.campus.domain.user.domain.entity.User;
 
 @Repository
 public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+	Page<Inquiry> findAllByWriterOrderByCreatedAtDesc(User writer, Pageable pageable);
 }

--- a/src/main/java/com/campus/campus/domain/inquiry/domain/repository/InquiryRepository.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/domain/repository/InquiryRepository.java
@@ -1,0 +1,10 @@
+package com.campus.campus.domain.inquiry.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.campus.campus.domain.inquiry.domain.entity.Inquiry;
+
+@Repository
+public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+}

--- a/src/main/java/com/campus/campus/domain/inquiry/presentation/InquiryController.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/presentation/InquiryController.java
@@ -1,0 +1,37 @@
+package com.campus.campus.domain.inquiry.presentation;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.campus.campus.domain.inquiry.application.dto.request.InquiryCreateRequest;
+import com.campus.campus.domain.inquiry.application.dto.response.InquiryCreateResponse;
+import com.campus.campus.domain.inquiry.application.service.InquiryService;
+import com.campus.campus.global.annotation.CurrentUserId;
+import com.campus.campus.global.common.response.CommonResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/inquiries")
+@RequiredArgsConstructor
+public class InquiryController {
+
+	private final InquiryService inquiryService;
+
+	@PostMapping
+	@Operation(
+		summary = "1:1 문의 등록",
+		description = "제목과 내용을 입력하여 새로운 문의를 등록합니다."
+	)
+	public CommonResponse<InquiryCreateResponse> create(
+		@Valid @RequestBody InquiryCreateRequest request,
+		@CurrentUserId Long userId
+	) {
+		InquiryCreateResponse response = inquiryService.createInquiry(userId, request);
+		return CommonResponse.success(InquiryResponseCode.INQUIRY_CREATE_SUCCESS, response);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/inquiry/presentation/InquiryController.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/presentation/InquiryController.java
@@ -1,5 +1,9 @@
 package com.campus.campus.domain.inquiry.presentation;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -7,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.campus.campus.domain.inquiry.application.dto.request.InquiryCreateRequest;
 import com.campus.campus.domain.inquiry.application.dto.response.InquiryCreateResponse;
+import com.campus.campus.domain.inquiry.application.dto.response.InquiryListItemResponse;
 import com.campus.campus.domain.inquiry.application.service.InquiryService;
 import com.campus.campus.global.annotation.CurrentUserId;
 import com.campus.campus.global.common.response.CommonResponse;
@@ -33,5 +38,18 @@ public class InquiryController {
 	) {
 		InquiryCreateResponse response = inquiryService.createInquiry(userId, request);
 		return CommonResponse.success(InquiryResponseCode.INQUIRY_CREATE_SUCCESS, response);
+	}
+
+	@GetMapping("/me")
+	@Operation(
+		summary = "내 문의 내역 조회",
+		description = "내가 작성한 문의 목록을 최신순으로 페이징하여 조회합니다. 아코디언 UI를 위해 상세 내용과 답변을 포함합니다."
+	)
+	public CommonResponse<Page<InquiryListItemResponse>> getMyInquiries(
+		@CurrentUserId Long userId,
+		@PageableDefault(size = 10) Pageable pageable
+	) {
+		Page<InquiryListItemResponse> response = inquiryService.getMyInquiries(userId, pageable);
+		return CommonResponse.success(InquiryResponseCode.INQUIRY_READ_SUCCESS, response);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/inquiry/presentation/InquiryController.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/presentation/InquiryController.java
@@ -3,6 +3,7 @@ package com.campus.campus.domain.inquiry.presentation;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,11 +18,14 @@ import com.campus.campus.global.annotation.CurrentUserId;
 import com.campus.campus.global.common.response.CommonResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/inquiries")
+@RequestMapping("users/inquiries")
+@PreAuthorize("hasRole('USER')")
+@Tag(name = "User Inquiry", description = "사용자(USER) 권한 전용 문의 API")
 @RequiredArgsConstructor
 public class InquiryController {
 
@@ -29,7 +33,7 @@ public class InquiryController {
 
 	@PostMapping
 	@Operation(
-		summary = "1:1 문의 등록",
+		summary = "일반 학생용 1:1 문의 등록",
 		description = "제목과 내용을 입력하여 새로운 문의를 등록합니다."
 	)
 	public CommonResponse<InquiryCreateResponse> create(
@@ -42,7 +46,7 @@ public class InquiryController {
 
 	@GetMapping("/me")
 	@Operation(
-		summary = "내 문의 내역 조회",
+		summary = "일반 학생의 문의 내역 조회",
 		description = "내가 작성한 문의 목록을 최신순으로 페이징하여 조회합니다. 아코디언 UI를 위해 상세 내용과 답변을 포함합니다."
 	)
 	public CommonResponse<Page<InquiryListItemResponse>> getMyInquiries(

--- a/src/main/java/com/campus/campus/domain/inquiry/presentation/InquiryResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/presentation/InquiryResponseCode.java
@@ -1,0 +1,19 @@
+package com.campus.campus.domain.inquiry.presentation;
+
+import org.springframework.http.HttpStatus;
+
+import com.campus.campus.global.common.response.ResponseCodeInterface;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum InquiryResponseCode implements ResponseCodeInterface {
+
+	INQUIRY_CREATE_SUCCESS(201, HttpStatus.CREATED, "문의 생성에 성공했습니다.");
+
+	private final int code;
+	private final HttpStatus status;
+	private final String message;
+}

--- a/src/main/java/com/campus/campus/domain/inquiry/presentation/InquiryResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/presentation/InquiryResponseCode.java
@@ -11,7 +11,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum InquiryResponseCode implements ResponseCodeInterface {
 
-	INQUIRY_CREATE_SUCCESS(201, HttpStatus.CREATED, "문의 생성에 성공했습니다.");
+	INQUIRY_CREATE_SUCCESS(201, HttpStatus.CREATED, "문의 생성에 성공했습니다."),
+	INQUIRY_READ_SUCCESS(200, HttpStatus.OK, "문의 내역 조회에 성공했습니다.");
 
 	private final int code;
 	private final HttpStatus status;

--- a/src/main/java/com/campus/campus/domain/inquiry/presentation/StudentCouncilInquiryController.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/presentation/StudentCouncilInquiryController.java
@@ -1,0 +1,59 @@
+package com.campus.campus.domain.inquiry.presentation;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.campus.campus.domain.inquiry.application.dto.request.InquiryCreateRequest;
+import com.campus.campus.domain.inquiry.application.dto.response.InquiryCreateResponse;
+import com.campus.campus.domain.inquiry.application.dto.response.InquiryListItemResponse;
+import com.campus.campus.domain.inquiry.application.service.StudentCouncilInquiryService;
+import com.campus.campus.global.annotation.CurrentCouncilId;
+import com.campus.campus.global.common.response.CommonResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("student-councils/inquiries")
+@PreAuthorize("hasRole('COUNCIL')")
+@Tag(name = "Student Council Inquiry", description = "학생회(COUNCIL) 권한 전용 문의 API")
+@RequiredArgsConstructor
+public class StudentCouncilInquiryController {
+
+	private final StudentCouncilInquiryService studentCouncilInquiryService;
+
+	@PostMapping
+	@Operation(
+		summary = "학생회용 1:1 문의 등록",
+		description = "제목과 내용을 입력하여 새로운 문의를 등록합니다."
+	)
+	public CommonResponse<InquiryCreateResponse> create(
+		@Valid @RequestBody InquiryCreateRequest request,
+		@CurrentCouncilId Long councilId
+	) {
+		InquiryCreateResponse response = studentCouncilInquiryService.createInquiry(councilId, request);
+		return CommonResponse.success(InquiryResponseCode.INQUIRY_CREATE_SUCCESS, response);
+	}
+
+	@GetMapping("/me")
+	@Operation(
+		summary = "학생회의 문의 내역 조회",
+		description = "학생회가 작성한 문의 목록을 최신순으로 페이징하여 조회합니다. 아코디언 UI를 위해 상세 내용과 답변을 포함합니다."
+	)
+	public CommonResponse<Page<InquiryListItemResponse>> getMyInquiries(
+		@CurrentCouncilId Long councilId,
+		@PageableDefault(size = 10) Pageable pageable
+	) {
+		Page<InquiryListItemResponse> response = studentCouncilInquiryService.getMyInquiries(councilId, pageable);
+		return CommonResponse.success(InquiryResponseCode.INQUIRY_READ_SUCCESS, response);
+	}
+}


### PR DESCRIPTION
## 🔀 변경 내용
- 문의(Inquiry) 도메인 설계 및 다변화 대응 API 구현
  - 일반 사용자(User)와 학생회(StudentCouncil)가 각각 서비스에 문의를 등록할 수 있도록 다중 연관관계 구조를 설계했습니다.
  - 작성자 타입별(USER, COUNCIL) 전용 엔드포인트를 분리하였습니다.
  - 제목과 본문(10자 이상)을 입력해 문의를 등록하는 기능을 추가했습니다.
  - 사용자가 본인이 작성한 문의 내역을 최신순으로 페이징하여 조회하는 기능을 추가했습니다.
  - 아코디언 UI 대응을 위해 목록 조회 시 상세 내용 및 답변 데이터를 포함하도록 설계했습니다.

## ✅ 작업 항목
- [x] Inquiry 엔티티 내 User 및 StudentCouncil 다중 외래키 구조 설계
- [x] 엔티티 내 공통 식별자 추출 로직(getWriterId, getWriterType) 구현
- [x] InquiryCreateRequest 유효성 검사 적용 (내용 10자~1000자)
- [x] 작성자 타입별 InquiryMapper 오버로딩 및 DTO 매핑 고도화
- [x] 일반 사용자용/학생회용 서비스 로직 분리 (InquiryService, StudentCouncilInquiryService)
- [x] 학생회 전용 관리자 승인 여부(managerApproved) 및 삭제 여부 검증 추가
- [x] GET /inquiries/me 및 GET /council/inquiries/me 페이징 조회 API 구현
- [x] API 응답용 InquiryResponseCode 정의

## 📸 스크린샷 (선택)
- 카카오톡 로그인이 되지 않아 Swagger 테스트는 진행하지 못 했습니다..

## 📎 참고 이슈
관련 이슈 번호 #103 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자 및 학생회용 1:1 문의 작성 및 목록 조회(API) 추가
  * 문의 작성 요청에 제목/내용 유효성 검사(빈값·길이) 적용
  * 문의 목록 페이징(최신순) 및 페이지 기본 사이즈 제공
  * 생성/목록 응답에 작성자 유형, 상태, 생성·답변 시간 등 상세 정보 포함
  * 문의 답변 등록 시 상태 변경 및 답변 시각 기록 지원
<!-- end of auto-generated comment: release notes by coderabbit.ai -->