### PR TITLE
feat/#108: 관리자 문의 관리 및 답변 기능 구현

### DIFF
--- a/src/main/java/com/campus/campus/domain/inquiry/application/dto/response/InquiryListItemResponse.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/application/dto/response/InquiryListItemResponse.java
@@ -11,6 +11,9 @@ public record InquiryListItemResponse(
 	@Schema(description = "작성자 ID", example = "2")
 	Long writerId,
 
+	@Schema(description = "작성자 이름", example = "홍길동")
+	String writerName,
+
 	@Schema(description = "작성자 타입", example = "USER || STUDENT_COUNCIL")
 	String writerType,
 

--- a/src/main/java/com/campus/campus/domain/inquiry/application/exception/AlreadyAnsweredInquiry.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/application/exception/AlreadyAnsweredInquiry.java
@@ -1,0 +1,10 @@
+package com.campus.campus.domain.inquiry.application.exception;
+
+import com.campus.campus.domain.user.application.exception.ErrorCode;
+import com.campus.campus.global.common.exception.ApplicationException;
+
+public class AlreadyAnsweredInquiry extends ApplicationException {
+	public AlreadyAnsweredInquiry() {
+		super(ErrorCode.ALREADY_ANSWERED_INQUIRY);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/inquiry/application/exception/InquiryNotFoundException.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/application/exception/InquiryNotFoundException.java
@@ -1,0 +1,10 @@
+package com.campus.campus.domain.inquiry.application.exception;
+
+import com.campus.campus.domain.user.application.exception.ErrorCode;
+import com.campus.campus.global.common.exception.ApplicationException;
+
+public class InquiryNotFoundException extends ApplicationException {
+	public InquiryNotFoundException() {
+		super(ErrorCode.INQUIRY_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/inquiry/application/mapper/InquiryMapper.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/application/mapper/InquiryMapper.java
@@ -50,6 +50,7 @@ public class InquiryMapper {
 		return new InquiryListItemResponse(
 			inquiry.getId(),
 			inquiry.getWriterId(),
+			inquiry.getWriterName(),
 			inquiry.getWriterType(),
 			inquiry.getTitle(),
 			inquiry.getContent(),

--- a/src/main/java/com/campus/campus/domain/inquiry/domain/entity/Inquiry.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/domain/entity/Inquiry.java
@@ -3,6 +3,7 @@ package com.campus.campus.domain.inquiry.domain.entity;
 import java.time.LocalDateTime;
 
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
+import com.campus.campus.domain.inquiry.application.exception.AlreadyAnsweredInquiry;
 import com.campus.campus.domain.user.domain.entity.User;
 import com.campus.campus.global.entity.BaseEntity;
 
@@ -85,6 +86,10 @@ public class Inquiry extends BaseEntity {
 	}
 
 	public void updateAnswer(String answer) {
+		if (this.status == InquiryStatus.COMPLETED) {
+			throw new AlreadyAnsweredInquiry();
+		}
+
 		this.answer = answer;
 		this.status = InquiryStatus.COMPLETED;
 		this.answeredAt = LocalDateTime.now();

--- a/src/main/java/com/campus/campus/domain/inquiry/domain/entity/Inquiry.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/domain/entity/Inquiry.java
@@ -70,6 +70,16 @@ public class Inquiry extends BaseEntity {
 		return null;
 	}
 
+	public String getWriterName() {
+		if (this.writerType == WriterType.USER && this.writer != null) {
+			return this.writer.getNickname();
+		}
+		if (this.writerType == WriterType.STUDENT_COUNCIL && this.studentCouncilWriter != null) {
+			return this.studentCouncilWriter.getCouncilName();
+		}
+		return "알 수 없음";
+	}
+
 	public String getWriterType() {
 		return (this.writer != null) ? this.writerType.name() : null;
 	}

--- a/src/main/java/com/campus/campus/domain/inquiry/domain/repository/InquiryRepository.java
+++ b/src/main/java/com/campus/campus/domain/inquiry/domain/repository/InquiryRepository.java
@@ -1,12 +1,18 @@
 package com.campus.campus.domain.inquiry.domain.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.inquiry.domain.entity.Inquiry;
+import com.campus.campus.domain.inquiry.domain.entity.InquiryStatus;
+import com.campus.campus.domain.inquiry.domain.entity.WriterType;
 import com.campus.campus.domain.user.domain.entity.User;
 
 @Repository
@@ -14,4 +20,17 @@ public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
 	Page<Inquiry> findAllByWriterOrderByCreatedAtDesc(User writer, Pageable pageable);
 
 	Page<Inquiry> findAllByStudentCouncilWriterOrderByCreatedAtDesc(StudentCouncil council, Pageable pageable);
+
+	@Query("""
+		SELECT i FROM Inquiry i
+		LEFT JOIN FETCH i.writer u
+		LEFT JOIN FETCH i.studentCouncilWriter sc
+		WHERE (:status IS NULL OR i.status = :status)
+			AND (:writerType IS NULL OR i.writerType = :writerType)
+		ORDER BY i.createdAt DESC
+		""")
+	List<Inquiry> findAllByCondition(
+		@Param("status") InquiryStatus status,
+		@Param("writerType") WriterType writerType
+	);
 }

--- a/src/main/java/com/campus/campus/domain/manager/application/dto/request/InquiryAnswerRequest.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/dto/request/InquiryAnswerRequest.java
@@ -1,0 +1,11 @@
+package com.campus.campus.domain.manager.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record InquiryAnswerRequest(
+	@Schema(description = "답변 내용", example = "문의하신 내용에 대한 답변입니다.")
+	@NotBlank(message = "답변 내용은 비어있을 수 없습니다.")
+	String answer
+) {
+}

--- a/src/main/java/com/campus/campus/domain/manager/application/dto/request/InquirySearchCondition.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/dto/request/InquirySearchCondition.java
@@ -5,7 +5,7 @@ import com.campus.campus.domain.inquiry.domain.entity.InquiryStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record InquirySearchCondition(
-	@Schema(description = "작성자 타입(미입력 시 전체 조회)", allowableValues = {"USER", "COUNCIL"})
+	@Schema(description = "작성자 타입(미입력 시 전체 조회)", allowableValues = {"USER", "STUDENT_COUNCIL"})
 	String writerType,
 
 	@Schema(description = "문의 상태(미입력 시 전체 조회)", example = "WAITING || COMPLETED")

--- a/src/main/java/com/campus/campus/domain/manager/application/dto/request/InquirySearchCondition.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/dto/request/InquirySearchCondition.java
@@ -1,0 +1,14 @@
+package com.campus.campus.domain.manager.application.dto.request;
+
+import com.campus.campus.domain.inquiry.domain.entity.InquiryStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record InquirySearchCondition(
+	@Schema(description = "작성자 타입(미입력 시 전체 조회)", allowableValues = {"USER", "COUNCIL"})
+	String writerType,
+
+	@Schema(description = "문의 상태(미입력 시 전체 조회)", example = "WAITING || COMPLETED")
+	InquiryStatus status
+) {
+}

--- a/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
@@ -148,8 +148,10 @@ public class ManagerService {
 	}
 
 	public List<InquiryListItemResponse> getAllInquiries(InquirySearchCondition condition) {
+		String writerTypeInput = (condition.writerType() != null) ? condition.writerType().trim() : "";
+
 		WriterType type = Arrays.stream(WriterType.values())
-			.filter(t -> t.name().equalsIgnoreCase(condition.writerType()))
+			.filter(t -> t.name().equalsIgnoreCase(writerTypeInput))
 			.findFirst()
 			.orElse(null);
 

--- a/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
@@ -15,11 +15,13 @@ import com.campus.campus.domain.council.application.exception.StudentCouncilNotF
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.council.domain.repository.StudentCouncilRepository;
 import com.campus.campus.domain.inquiry.application.dto.response.InquiryListItemResponse;
+import com.campus.campus.domain.inquiry.application.exception.InquiryNotFoundException;
 import com.campus.campus.domain.inquiry.application.mapper.InquiryMapper;
 import com.campus.campus.domain.inquiry.domain.entity.Inquiry;
 import com.campus.campus.domain.inquiry.domain.entity.WriterType;
 import com.campus.campus.domain.inquiry.domain.repository.InquiryRepository;
 import com.campus.campus.domain.manager.application.dto.request.CouncilApproveOrDenyRequest;
+import com.campus.campus.domain.manager.application.dto.request.InquiryAnswerRequest;
 import com.campus.campus.domain.manager.application.dto.request.InquirySearchCondition;
 import com.campus.campus.domain.manager.application.dto.request.ManagerLoginRequest;
 import com.campus.campus.domain.manager.application.dto.request.RewardRequest;
@@ -159,6 +161,14 @@ public class ManagerService {
 		return inquiries.stream()
 			.map(inquiryMapper::toInquiryListItemResponse)
 			.toList();
+	}
+
+	@Transactional
+	public void answerInquiry(Long inquiryId, InquiryAnswerRequest request) {
+		Inquiry inquiry = inquiryRepository.findById(inquiryId)
+			.orElseThrow(InquiryNotFoundException::new);
+
+		inquiry.updateAnswer(request.answer());
 	}
 
 	private void sendCouncilApprovedMail(String to) {

--- a/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
@@ -9,16 +9,23 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import com.campus.campus.domain.council.application.exception.StudentCouncilNotFoundException;
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.council.domain.repository.StudentCouncilRepository;
+import com.campus.campus.domain.inquiry.application.dto.response.InquiryListItemResponse;
+import com.campus.campus.domain.inquiry.application.mapper.InquiryMapper;
+import com.campus.campus.domain.inquiry.domain.entity.Inquiry;
+import com.campus.campus.domain.inquiry.domain.entity.WriterType;
+import com.campus.campus.domain.inquiry.domain.repository.InquiryRepository;
 import com.campus.campus.domain.manager.application.dto.request.CouncilApproveOrDenyRequest;
+import com.campus.campus.domain.manager.application.dto.request.InquirySearchCondition;
 import com.campus.campus.domain.manager.application.dto.request.ManagerLoginRequest;
 import com.campus.campus.domain.manager.application.dto.request.RewardRequest;
+import com.campus.campus.domain.manager.application.dto.response.CertifyRequestCouncilListResponse;
 import com.campus.campus.domain.manager.application.dto.response.CertifyRequestCouncilResponse;
 import com.campus.campus.domain.manager.application.dto.response.CouncilApproveOrDenyResponse;
-import com.campus.campus.domain.manager.application.dto.response.CertifyRequestCouncilListResponse;
 import com.campus.campus.domain.manager.application.dto.response.ManagerLoginResponse;
 import com.campus.campus.domain.manager.application.dto.response.StampRewardNeededUserListResponse;
 import com.campus.campus.domain.manager.application.exception.ManagerNotFoundException;
@@ -44,10 +51,12 @@ public class ManagerService {
 	private final ManagerRepository managerRepository;
 	private final UserRepository userRepository;
 	private final RewardRepository rewardRepository;
+	private final InquiryRepository inquiryRepository;
 	private final PasswordEncoder passwordEncoder;
 	private final JwtProvider jwtProvider;
 	private final RedisTokenService redisTokenService;
 	private final ManagerMapper managerMapper;
+	private final InquiryMapper inquiryMapper;
 	private final JavaMailSender javaMailSender;
 	private final ApplicationEventPublisher eventPublisher;
 
@@ -134,6 +143,22 @@ public class ManagerService {
 		user.updateRewardNeeded(false);
 
 		eventPublisher.publishEvent(managerMapper.createRewardGrantedEvent(userId, "스탬프 보상"));
+	}
+
+	public List<InquiryListItemResponse> getAllInquiries(InquirySearchCondition condition) {
+		WriterType type = null;
+		if (StringUtils.hasText(condition.writerType())) {
+			type = WriterType.valueOf(condition.writerType().toUpperCase());
+		}
+
+		List<Inquiry> inquiries = inquiryRepository.findAllByCondition(
+			condition.status(),
+			type
+		);
+
+		return inquiries.stream()
+			.map(inquiryMapper::toInquiryListItemResponse)
+			.toList();
 	}
 
 	private void sendCouncilApprovedMail(String to) {

--- a/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
@@ -1,5 +1,6 @@
 package com.campus.campus.domain.manager.application.service;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -9,7 +10,6 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 import com.campus.campus.domain.council.application.exception.StudentCouncilNotFoundException;
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
@@ -148,15 +148,10 @@ public class ManagerService {
 	}
 
 	public List<InquiryListItemResponse> getAllInquiries(InquirySearchCondition condition) {
-		WriterType type = null;
-
-		if (StringUtils.hasText(condition.writerType())) {
-			try {
-				type = WriterType.valueOf(condition.writerType().toUpperCase());
-			} catch (IllegalArgumentException e) {
-				type = null;
-			}
-		}
+		WriterType type = Arrays.stream(WriterType.values())
+			.filter(t -> t.name().equalsIgnoreCase(condition.writerType()))
+			.findFirst()
+			.orElse(null);
 
 		List<Inquiry> inquiries = inquiryRepository.findAllByCondition(
 			condition.status(),

--- a/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
@@ -149,8 +149,13 @@ public class ManagerService {
 
 	public List<InquiryListItemResponse> getAllInquiries(InquirySearchCondition condition) {
 		WriterType type = null;
+
 		if (StringUtils.hasText(condition.writerType())) {
-			type = WriterType.valueOf(condition.writerType().toUpperCase());
+			try {
+				type = WriterType.valueOf(condition.writerType().toUpperCase());
+			} catch (IllegalArgumentException e) {
+				type = null;
+			}
 		}
 
 		List<Inquiry> inquiries = inquiryRepository.findAllByCondition(

--- a/src/main/java/com/campus/campus/domain/manager/presentation/ManagerController.java
+++ b/src/main/java/com/campus/campus/domain/manager/presentation/ManagerController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.campus.campus.domain.inquiry.application.dto.response.InquiryListItemResponse;
 import com.campus.campus.domain.manager.application.dto.request.CouncilApproveOrDenyRequest;
+import com.campus.campus.domain.manager.application.dto.request.InquiryAnswerRequest;
 import com.campus.campus.domain.manager.application.dto.request.InquirySearchCondition;
 import com.campus.campus.domain.manager.application.dto.request.ManagerLoginRequest;
 import com.campus.campus.domain.manager.application.dto.request.RewardRequest;
@@ -105,6 +106,20 @@ public class ManagerController {
 		@ParameterObject @Valid InquirySearchCondition condition
 	) {
 		List<InquiryListItemResponse> response = managerService.getAllInquiries(condition);
-		return CommonResponse.success(ManagerResponseCode.INQUIRY__LIST_SUCCESS, response);
+		return CommonResponse.success(ManagerResponseCode.INQUIRY_LIST_SUCCESS, response);
+	}
+
+	@PatchMapping("/inquiries/{inquiryId}/answer")
+	@PreAuthorize("hasRole('MANAGER')")
+	@Operation(
+		summary = "문의 답변 작성",
+		description = "특정 ID의 문의에 대해 답변을 작성합니다."
+	)
+	public CommonResponse<Void> answerInquiry(
+		@PathVariable Long inquiryId,
+		@Valid @RequestBody InquiryAnswerRequest request
+	) {
+		managerService.answerInquiry(inquiryId, request);
+		return CommonResponse.success(ManagerResponseCode.INQUIRY_ANSWER_SUCCESS);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/manager/presentation/ManagerController.java
+++ b/src/main/java/com/campus/campus/domain/manager/presentation/ManagerController.java
@@ -2,6 +2,7 @@ package com.campus.campus.domain.manager.presentation;
 
 import java.util.List;
 
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -11,12 +12,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.campus.campus.domain.inquiry.application.dto.response.InquiryListItemResponse;
 import com.campus.campus.domain.manager.application.dto.request.CouncilApproveOrDenyRequest;
+import com.campus.campus.domain.manager.application.dto.request.InquirySearchCondition;
 import com.campus.campus.domain.manager.application.dto.request.ManagerLoginRequest;
 import com.campus.campus.domain.manager.application.dto.request.RewardRequest;
+import com.campus.campus.domain.manager.application.dto.response.CertifyRequestCouncilListResponse;
 import com.campus.campus.domain.manager.application.dto.response.CertifyRequestCouncilResponse;
 import com.campus.campus.domain.manager.application.dto.response.CouncilApproveOrDenyResponse;
-import com.campus.campus.domain.manager.application.dto.response.CertifyRequestCouncilListResponse;
 import com.campus.campus.domain.manager.application.dto.response.ManagerLoginResponse;
 import com.campus.campus.domain.manager.application.dto.response.StampRewardNeededUserListResponse;
 import com.campus.campus.domain.manager.application.service.ManagerService;
@@ -90,5 +93,18 @@ public class ManagerController {
 		managerService.grantRewardToUser(userId, rewardRequest);
 
 		return CommonResponse.success(ManagerResponseCode.GRANT_REWARD_SUCCESS);
+	}
+
+	@GetMapping("/inquiries")
+	@PreAuthorize("hasRole('MANAGER')")
+	@Operation(
+		summary = "전체 문의 내역 조회",
+		description = "작성자 타입과 답변 상태에 따라 문의를 필터링하여 조회합니다."
+	)
+	public CommonResponse<List<InquiryListItemResponse>> getAllInquiries(
+		@ParameterObject @Valid InquirySearchCondition condition
+	) {
+		List<InquiryListItemResponse> response = managerService.getAllInquiries(condition);
+		return CommonResponse.success(ManagerResponseCode.INQUIRY__LIST_SUCCESS, response);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/manager/presentation/ManagerResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/manager/presentation/ManagerResponseCode.java
@@ -16,7 +16,8 @@ public enum ManagerResponseCode implements ResponseCodeInterface {
 	CERTIFY_REQUEST_ELECTION_IMAGE_SUCCESS(200, HttpStatus.OK, "해당 학생회 인증 요청 당선 사진 조회에 성공했습니다."),
 	REWARD_NEEDED_USER_LIST_SUCCESS(200, HttpStatus.OK, "스탬프 보상이 필요한 유저 목록 조회에 성공했습니다."),
 	GRANT_REWARD_SUCCESS(200, HttpStatus.OK, "스탬프 보상 지급에 성공했습니다."),
-	INQUIRY_LIST_SUCCESS(200, HttpStatus.OK, "문의 내역 조회에 성공했습니다.");
+	INQUIRY_LIST_SUCCESS(200, HttpStatus.OK, "문의 내역 조회에 성공했습니다."),
+	INQUIRY_ANSWER_SUCCESS(200, HttpStatus.OK, "문의에 답변이 작성되었습니다.");
 
 	private final int code;
 	private final HttpStatus status;

--- a/src/main/java/com/campus/campus/domain/manager/presentation/ManagerResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/manager/presentation/ManagerResponseCode.java
@@ -15,7 +15,8 @@ public enum ManagerResponseCode implements ResponseCodeInterface {
 	CERTIFY_REQUEST_LIST_SUCCESS(200, HttpStatus.OK, "학생회 인증 요청 목록 조회에 성공했습니다."),
 	CERTIFY_REQUEST_ELECTION_IMAGE_SUCCESS(200, HttpStatus.OK, "해당 학생회 인증 요청 당선 사진 조회에 성공했습니다."),
 	REWARD_NEEDED_USER_LIST_SUCCESS(200, HttpStatus.OK, "스탬프 보상이 필요한 유저 목록 조회에 성공했습니다."),
-	GRANT_REWARD_SUCCESS(200, HttpStatus.OK, "스탬프 보상 지급에 성공했습니다.");
+	GRANT_REWARD_SUCCESS(200, HttpStatus.OK, "스탬프 보상 지급에 성공했습니다."),
+	INQUIRY__LIST_SUCCESS(200, HttpStatus.OK, "문의 내역 조회에 성공했습니다.");
 
 	private final int code;
 	private final HttpStatus status;

--- a/src/main/java/com/campus/campus/domain/manager/presentation/ManagerResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/manager/presentation/ManagerResponseCode.java
@@ -16,7 +16,7 @@ public enum ManagerResponseCode implements ResponseCodeInterface {
 	CERTIFY_REQUEST_ELECTION_IMAGE_SUCCESS(200, HttpStatus.OK, "해당 학생회 인증 요청 당선 사진 조회에 성공했습니다."),
 	REWARD_NEEDED_USER_LIST_SUCCESS(200, HttpStatus.OK, "스탬프 보상이 필요한 유저 목록 조회에 성공했습니다."),
 	GRANT_REWARD_SUCCESS(200, HttpStatus.OK, "스탬프 보상 지급에 성공했습니다."),
-	INQUIRY__LIST_SUCCESS(200, HttpStatus.OK, "문의 내역 조회에 성공했습니다.");
+	INQUIRY_LIST_SUCCESS(200, HttpStatus.OK, "문의 내역 조회에 성공했습니다.");
 
 	private final int code;
 	private final HttpStatus status;

--- a/src/main/java/com/campus/campus/domain/user/application/exception/ErrorCode.java
+++ b/src/main/java/com/campus/campus/domain/user/application/exception/ErrorCode.java
@@ -16,7 +16,8 @@ public enum ErrorCode implements ErrorCodeInterface {
 	USER_SIGNUP_FORBIDDEN_NOW(2103, HttpStatus.FORBIDDEN, "현재 회원가입할 수 없는 계정입니다."),
 	NICKNAME_ALREADY_EXISTS(2104, HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
 	ACADEMIC_INFO_CANNOT_CHANGE(2105, HttpStatus.BAD_REQUEST, "학적 정보는 6개월에 한번만 변경 가능합니다."),
-	CAU_SCHOOL_ONLY(2106, HttpStatus.BAD_REQUEST, "중앙대학교 학생만 가입할 수 있습니다.");
+	CAU_SCHOOL_ONLY(2106, HttpStatus.BAD_REQUEST, "중앙대학교 학생만 가입할 수 있습니다."),
+	INQUIRY_NOT_FOUND(2107, HttpStatus.BAD_REQUEST, "존재하지 않는 문의입니다.");
 
 	private final int code;
 	private final HttpStatus status;

--- a/src/main/java/com/campus/campus/domain/user/application/exception/ErrorCode.java
+++ b/src/main/java/com/campus/campus/domain/user/application/exception/ErrorCode.java
@@ -17,7 +17,8 @@ public enum ErrorCode implements ErrorCodeInterface {
 	NICKNAME_ALREADY_EXISTS(2104, HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
 	ACADEMIC_INFO_CANNOT_CHANGE(2105, HttpStatus.BAD_REQUEST, "학적 정보는 6개월에 한번만 변경 가능합니다."),
 	CAU_SCHOOL_ONLY(2106, HttpStatus.BAD_REQUEST, "중앙대학교 학생만 가입할 수 있습니다."),
-	INQUIRY_NOT_FOUND(2107, HttpStatus.BAD_REQUEST, "존재하지 않는 문의입니다.");
+	INQUIRY_NOT_FOUND(2107, HttpStatus.BAD_REQUEST, "존재하지 않는 문의입니다."),
+	ALREADY_ANSWERED_INQUIRY(2108, HttpStatus.BAD_REQUEST, "이미 답변이 완료된 문의입니다.");
 
 	private final int code;
 	private final HttpStatus status;

--- a/src/main/java/com/campus/campus/domain/user/application/exception/ErrorCode.java
+++ b/src/main/java/com/campus/campus/domain/user/application/exception/ErrorCode.java
@@ -17,7 +17,7 @@ public enum ErrorCode implements ErrorCodeInterface {
 	NICKNAME_ALREADY_EXISTS(2104, HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
 	ACADEMIC_INFO_CANNOT_CHANGE(2105, HttpStatus.BAD_REQUEST, "학적 정보는 6개월에 한번만 변경 가능합니다."),
 	CAU_SCHOOL_ONLY(2106, HttpStatus.BAD_REQUEST, "중앙대학교 학생만 가입할 수 있습니다."),
-	INQUIRY_NOT_FOUND(2107, HttpStatus.BAD_REQUEST, "존재하지 않는 문의입니다."),
+	INQUIRY_NOT_FOUND(2107, HttpStatus.NOT_FOUND, "존재하지 않는 문의입니다."),
 	ALREADY_ANSWERED_INQUIRY(2108, HttpStatus.BAD_REQUEST, "이미 답변이 완료된 문의입니다.");
 
 	private final int code;


### PR DESCRIPTION
## 🔀 변경 내용
- 문의(Inquiry) 도메인 신설: 1:1 문의 저장을 위한 엔티티 및 테이블 매핑을 완료했습니다.
- 관리자용 문의 필터링 조회 구현: 작성자 타입(전체/학생/학생회) 및 답변 상태(대기/완료)에 따른 동적 조회 API를 구현했습니다.
- 관리자 답변 작성 기능 구현: 특정 문의에 대해 답변을 등록하고 상태를 COMPLETED로 자동 전환하는 로직을 추가했습니다.
- 도메인 전용 예외 처리: 문의를 찾을 수 없는 경우 발생하는 InquiryNotFoundException을 추가하여 에러 응답의 일관성을 높였습니다.

## ✅ 작업 항목
- [x] Inquiry 엔티티 및 InquiryRepository 생성
- [x] InquirySearchCondition을 이용한 관리자용 동적 조회 API 구현
- [x] InquiryMapper를 통한 엔티티-DTO 변환 로직 적용
- [x] 관리자 답변 작성(PATCH) 및 상태 업데이트 기능 구현
- [x] InquiryNotFoundException 커스텀 예외 추가


## 📸 스크린샷 (선택)

## 📎 참고 이슈
관련 이슈 번호 #108 

- 문의 작성 완료 후 알림 발송 여부에 대해서는 PM님께 답변 받은 후 추가 구현하거나 하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자가 문의를 검색·필터링하고 목록을 조회할 수 있는 기능 추가
  * 관리자가 특정 문의에 답변을 등록할 수 있는 기능 추가
  * 문의 목록 응답에 작성자 이름이 포함되어 표시됨
  * 답변 등록을 위한 요청 형식 및 검색 조건 입력이 추가됨

* **버그 수정**
  * 존재하지 않는 문의 요청에 대한 명확한 오류 응답 추가
  * 이미 답변된 문의에 대해 중복 답변이 방지되도록 처리 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->