### PR TITLE
feat/#110: 학생회 알림 발송 구축 및 문의 답변 작성 완료 시 알림 발송 구현

### DIFF
--- a/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
@@ -178,13 +178,17 @@ public class ManagerService {
 
 		inquiry.updateAnswer(request.answer());
 
-		if (inquiry.getWriter() != null) {
-			notificationService.saveInquiryAnsweredNotification(inquiry.getWriter(), inquiry.getId());
-		} else if (inquiry.getStudentCouncilWriter() != null) {
-			councilNotificationService.saveInquiryAnsweredNotification(inquiry.getStudentCouncilWriter(),
-				inquiry.getId());
-		} else {
-			log.warn("문의 ID={}에 대한 알림 수신자(User/Council)를 찾을 수 없습니다.", inquiry.getId());
+		try {
+			if (inquiry.getWriter() != null) {
+				notificationService.saveInquiryAnsweredNotification(inquiry.getWriter(), inquiry.getId());
+			} else if (inquiry.getStudentCouncilWriter() != null) {
+				councilNotificationService.saveInquiryAnsweredNotification(inquiry.getStudentCouncilWriter(),
+					inquiry.getId());
+			} else {
+				log.warn("문의 ID={}에 대한 알림 수신자(User/Council)를 찾을 수 없습니다.", inquiry.getId());
+			}
+		} catch (Exception e) {
+			log.error("문의 답변 알림 발송 중 오류 발생: inquiryId={}", inquiry.getId());
 		}
 	}
 

--- a/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
@@ -188,7 +188,7 @@ public class ManagerService {
 				log.warn("문의 ID={}에 대한 알림 수신자(User/Council)를 찾을 수 없습니다.", inquiry.getId());
 			}
 		} catch (Exception e) {
-			log.error("문의 답변 알림 발송 중 오류 발생: inquiryId={}", inquiry.getId());
+			log.error("문의 답변 알림 발송 중 오류 발생: inquiryId={}", inquiry.getId(), e);
 		}
 	}
 

--- a/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
@@ -46,7 +46,9 @@ import com.campus.campus.global.util.jwt.JwtProvider;
 import com.campus.campus.global.util.jwt.application.service.RedisTokenService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -178,9 +180,11 @@ public class ManagerService {
 
 		if (inquiry.getWriter() != null) {
 			notificationService.saveInquiryAnsweredNotification(inquiry.getWriter(), inquiry.getId());
-		} else {
+		} else if (inquiry.getStudentCouncilWriter() != null) {
 			councilNotificationService.saveInquiryAnsweredNotification(inquiry.getStudentCouncilWriter(),
 				inquiry.getId());
+		} else {
+			log.warn("문의 ID={}에 대한 알림 수신자(User/Council)를 찾을 수 없습니다.", inquiry.getId());
 		}
 	}
 

--- a/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
@@ -35,6 +35,8 @@ import com.campus.campus.domain.manager.application.exception.PasswordNotCorrect
 import com.campus.campus.domain.manager.application.mapper.ManagerMapper;
 import com.campus.campus.domain.manager.domain.entity.Manager;
 import com.campus.campus.domain.manager.domain.repository.ManagerRepository;
+import com.campus.campus.domain.notification.application.service.NotificationService;
+import com.campus.campus.domain.notification.application.service.StudentCouncilNotificationService;
 import com.campus.campus.domain.stamp.domain.entity.Reward;
 import com.campus.campus.domain.stamp.domain.repository.RewardRepository;
 import com.campus.campus.domain.user.application.exception.UserNotFoundException;
@@ -61,6 +63,8 @@ public class ManagerService {
 	private final InquiryMapper inquiryMapper;
 	private final JavaMailSender javaMailSender;
 	private final ApplicationEventPublisher eventPublisher;
+	private final NotificationService notificationService;
+	private final StudentCouncilNotificationService councilNotificationService;
 
 	@Value("${jwt.refresh.expiration-seconds}")
 	private long refreshTokenExpirationSeconds;
@@ -171,6 +175,13 @@ public class ManagerService {
 			.orElseThrow(InquiryNotFoundException::new);
 
 		inquiry.updateAnswer(request.answer());
+
+		if (inquiry.getWriter() != null) {
+			notificationService.saveInquiryAnsweredNotification(inquiry.getWriter(), inquiry.getId());
+		} else {
+			councilNotificationService.saveInquiryAnsweredNotification(inquiry.getStudentCouncilWriter(),
+				inquiry.getId());
+		}
 	}
 
 	private void sendCouncilApprovedMail(String to) {

--- a/src/main/java/com/campus/campus/domain/notification/application/mapper/NotificationMapper.java
+++ b/src/main/java/com/campus/campus/domain/notification/application/mapper/NotificationMapper.java
@@ -2,6 +2,7 @@ package com.campus.campus.domain.notification.application.mapper;
 
 import org.springframework.stereotype.Component;
 
+import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.notification.application.dto.NotificationResponse;
 import com.campus.campus.domain.notification.domain.entity.Notification;
 import com.campus.campus.domain.notification.domain.entity.NotificationType;
@@ -32,6 +33,17 @@ public class NotificationMapper {
 		String title, String body, Long referenceId) {
 		return Notification.builder()
 			.user(user)
+			.type(type)
+			.title(title)
+			.body(body)
+			.referenceId(referenceId)
+			.build();
+	}
+
+	public Notification createCouncilNotification(StudentCouncil council, NotificationType type,
+		String title, String body, Long referenceId) {
+		return Notification.builder()
+			.studentCouncil(council)
 			.type(type)
 			.title(title)
 			.body(body)

--- a/src/main/java/com/campus/campus/domain/notification/application/service/NotificationService.java
+++ b/src/main/java/com/campus/campus/domain/notification/application/service/NotificationService.java
@@ -117,6 +117,22 @@ public class NotificationService {
 		return notificationRepository.existsByUser_IdAndIsReadFalse(userId);
 	}
 
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void saveInquiryAnsweredNotification(User user, Long inquiryId) {
+		String title = "캠어스";
+		String body = "문의하신 내용에 답변이 도착했어요.";
+
+		Notification notification = notificationMapper.createNotification(
+			user,
+			NotificationType.SYSTEM_NOTICE,
+			title,
+			body,
+			inquiryId
+		);
+
+		notificationRepository.save(notification);
+	}
+
 	private List<User> findUsersByTopic(String topic) {
 
 		String[] parts = topic.split("_");

--- a/src/main/java/com/campus/campus/domain/notification/application/service/NotificationService.java
+++ b/src/main/java/com/campus/campus/domain/notification/application/service/NotificationService.java
@@ -117,7 +117,7 @@ public class NotificationService {
 		return notificationRepository.existsByUser_IdAndIsReadFalse(userId);
 	}
 
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional
 	public void saveInquiryAnsweredNotification(User user, Long inquiryId) {
 		String title = "캠어스";
 		String body = "문의하신 내용에 답변이 도착했어요.";

--- a/src/main/java/com/campus/campus/domain/notification/application/service/NotificationService.java
+++ b/src/main/java/com/campus/campus/domain/notification/application/service/NotificationService.java
@@ -117,7 +117,7 @@ public class NotificationService {
 		return notificationRepository.existsByUser_IdAndIsReadFalse(userId);
 	}
 
-	@Transactional
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void saveInquiryAnsweredNotification(User user, Long inquiryId) {
 		String title = "캠어스";
 		String body = "문의하신 내용에 답변이 도착했어요.";

--- a/src/main/java/com/campus/campus/domain/notification/application/service/StudentCouncilNotificationService.java
+++ b/src/main/java/com/campus/campus/domain/notification/application/service/StudentCouncilNotificationService.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.campus.campus.domain.council.application.exception.StudentCouncilNotFoundException;
@@ -86,7 +85,7 @@ public class StudentCouncilNotificationService {
 		return notificationRepository.existsByStudentCouncil_IdAndIsReadFalse(councilId);
 	}
 
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional
 	public void saveInquiryAnsweredNotification(StudentCouncil council, Long inquiryId) {
 		String title = "캠어스";
 		String body = "문의하신 내용에 답변이 도착했어요.";

--- a/src/main/java/com/campus/campus/domain/notification/application/service/StudentCouncilNotificationService.java
+++ b/src/main/java/com/campus/campus/domain/notification/application/service/StudentCouncilNotificationService.java
@@ -78,4 +78,9 @@ public class StudentCouncilNotificationService {
 
 		notification.markAsRead();
 	}
+
+	@Transactional(readOnly = true)
+	public boolean hasCouncilUnread(Long councilId) {
+		return notificationRepository.existsByStudentCouncil_IdAndIsReadFalse(councilId);
+	}
 }

--- a/src/main/java/com/campus/campus/domain/notification/application/service/StudentCouncilNotificationService.java
+++ b/src/main/java/com/campus/campus/domain/notification/application/service/StudentCouncilNotificationService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.campus.campus.domain.council.application.exception.StudentCouncilNotFoundException;
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
@@ -13,6 +14,8 @@ import com.campus.campus.domain.council.domain.repository.StudentCouncilReposito
 import com.campus.campus.domain.notification.application.dto.CursorResponse;
 import com.campus.campus.domain.notification.application.dto.NextCursor;
 import com.campus.campus.domain.notification.application.dto.NotificationResponse;
+import com.campus.campus.domain.notification.application.exception.NotificationAccessDeniedException;
+import com.campus.campus.domain.notification.application.exception.NotificationNotFoundException;
 import com.campus.campus.domain.notification.application.mapper.NotificationMapper;
 import com.campus.campus.domain.notification.domain.entity.Notification;
 import com.campus.campus.domain.notification.domain.repository.NotificationRepository;
@@ -24,7 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class StudentCouncilNotificationService {
-	
+
 	private final NotificationRepository notificationRepository;
 	private final NotificationMapper notificationMapper;
 	private final StudentCouncilRepository studentCouncilRepository;
@@ -57,5 +60,22 @@ public class StudentCouncilNotificationService {
 			new NextCursor(list.get(list.size() - 1).getCreatedAt(), list.get(list.size() - 1).getId());
 
 		return new CursorResponse<>(items, nextCursor, hasNext);
+	}
+
+	@Transactional
+	public void markCouncilNotificationAsRead(Long councilId, Long notificationId) {
+		StudentCouncil council = studentCouncilRepository
+			.findByIdAndManagerApprovedIsTrueAndDeletedAtIsNull(councilId)
+			.orElseThrow(StudentCouncilNotFoundException::new);
+
+		Notification notification = notificationRepository.findById(notificationId)
+			.orElseThrow(NotificationNotFoundException::new);
+
+		if (notification.getStudentCouncil() == null ||
+			!notification.getStudentCouncil().getId().equals(council.getId())) {
+			throw new NotificationAccessDeniedException();
+		}
+
+		notification.markAsRead();
 	}
 }

--- a/src/main/java/com/campus/campus/domain/notification/application/service/StudentCouncilNotificationService.java
+++ b/src/main/java/com/campus/campus/domain/notification/application/service/StudentCouncilNotificationService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.campus.campus.domain.council.application.exception.StudentCouncilNotFoundException;
@@ -85,7 +86,7 @@ public class StudentCouncilNotificationService {
 		return notificationRepository.existsByStudentCouncil_IdAndIsReadFalse(councilId);
 	}
 
-	@Transactional
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	public void saveInquiryAnsweredNotification(StudentCouncil council, Long inquiryId) {
 		String title = "캠어스";
 		String body = "문의하신 내용에 답변이 도착했어요.";

--- a/src/main/java/com/campus/campus/domain/notification/application/service/StudentCouncilNotificationService.java
+++ b/src/main/java/com/campus/campus/domain/notification/application/service/StudentCouncilNotificationService.java
@@ -1,0 +1,61 @@
+package com.campus.campus.domain.notification.application.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.campus.campus.domain.council.application.exception.StudentCouncilNotFoundException;
+import com.campus.campus.domain.council.domain.entity.StudentCouncil;
+import com.campus.campus.domain.council.domain.repository.StudentCouncilRepository;
+import com.campus.campus.domain.notification.application.dto.CursorResponse;
+import com.campus.campus.domain.notification.application.dto.NextCursor;
+import com.campus.campus.domain.notification.application.dto.NotificationResponse;
+import com.campus.campus.domain.notification.application.mapper.NotificationMapper;
+import com.campus.campus.domain.notification.domain.entity.Notification;
+import com.campus.campus.domain.notification.domain.repository.NotificationRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StudentCouncilNotificationService {
+	
+	private final NotificationRepository notificationRepository;
+	private final NotificationMapper notificationMapper;
+	private final StudentCouncilRepository studentCouncilRepository;
+
+	public CursorResponse<NotificationResponse> getCouncilNotificationsByCursor(
+		Long councilId,
+		LocalDateTime cursorCreatedAt,
+		Long cursorId,
+		int limit
+	) {
+		StudentCouncil council = studentCouncilRepository
+			.findByIdAndManagerApprovedIsTrueAndDeletedAtIsNull(councilId)
+			.orElseThrow(StudentCouncilNotFoundException::new);
+
+		int pageSize = Math.min(Math.max(limit, 1), 50);
+		Pageable pageable = PageRequest.of(0, pageSize);
+
+		boolean isFirst = (cursorCreatedAt == null || cursorId == null);
+
+		List<Notification> list = isFirst
+			? notificationRepository.findByStudentCouncilOrderByCreatedAtDescIdDesc(council, pageable)
+			: notificationRepository.findNextByCouncilCursor(council, cursorCreatedAt, cursorId, pageable);
+
+		List<NotificationResponse> items = list.stream()
+			.map(notificationMapper::toResponse)
+			.toList();
+
+		boolean hasNext = list.size() == pageSize;
+		NextCursor nextCursor = list.isEmpty() ? null :
+			new NextCursor(list.get(list.size() - 1).getCreatedAt(), list.get(list.size() - 1).getId());
+
+		return new CursorResponse<>(items, nextCursor, hasNext);
+	}
+}

--- a/src/main/java/com/campus/campus/domain/notification/application/service/StudentCouncilNotificationService.java
+++ b/src/main/java/com/campus/campus/domain/notification/application/service/StudentCouncilNotificationService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.campus.campus.domain.council.application.exception.StudentCouncilNotFoundException;
@@ -18,6 +19,7 @@ import com.campus.campus.domain.notification.application.exception.NotificationA
 import com.campus.campus.domain.notification.application.exception.NotificationNotFoundException;
 import com.campus.campus.domain.notification.application.mapper.NotificationMapper;
 import com.campus.campus.domain.notification.domain.entity.Notification;
+import com.campus.campus.domain.notification.domain.entity.NotificationType;
 import com.campus.campus.domain.notification.domain.repository.NotificationRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -82,5 +84,20 @@ public class StudentCouncilNotificationService {
 	@Transactional(readOnly = true)
 	public boolean hasCouncilUnread(Long councilId) {
 		return notificationRepository.existsByStudentCouncil_IdAndIsReadFalse(councilId);
+	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void saveInquiryAnsweredNotification(StudentCouncil council, Long inquiryId) {
+		String title = "캠어스";
+		String body = "문의하신 내용에 답변이 도착했어요.";
+
+		Notification notification = notificationMapper.createCouncilNotification(
+			council,
+			NotificationType.SYSTEM_NOTICE,
+			title,
+			body,
+			inquiryId
+		);
+		notificationRepository.save(notification);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/notification/domain/entity/Notification.java
+++ b/src/main/java/com/campus/campus/domain/notification/domain/entity/Notification.java
@@ -2,6 +2,7 @@ package com.campus.campus.domain.notification.domain.entity;
 
 import java.time.LocalDateTime;
 
+import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.user.domain.entity.User;
 import com.campus.campus.global.entity.BaseEntity;
 
@@ -30,8 +31,12 @@ public class Notification extends BaseEntity {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id", nullable = false)
+	@JoinColumn(name = "user_id")
 	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "student_council_id")
+	private StudentCouncil studentCouncil;
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
@@ -53,9 +58,10 @@ public class Notification extends BaseEntity {
 	private LocalDateTime readAt;
 
 	@Builder
-	public Notification(User user, NotificationType type, String title,
+	public Notification(User user, StudentCouncil studentCouncil, NotificationType type, String title,
 		String body, Long referenceId) {
 		this.user = user;
+		this.studentCouncil = studentCouncil;
 		this.type = type;
 		this.title = title;
 		this.body = body;

--- a/src/main/java/com/campus/campus/domain/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/campus/campus/domain/notification/domain/repository/NotificationRepository.java
@@ -33,6 +33,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 	);
 
 	boolean existsByUser_IdAndIsReadFalse(Long userId);
+	
+	boolean existsByStudentCouncil_IdAndIsReadFalse(Long councilId);
 
 	List<Notification> findByStudentCouncilOrderByCreatedAtDescIdDesc(StudentCouncil council, Pageable pageable);
 

--- a/src/main/java/com/campus/campus/domain/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/campus/campus/domain/notification/domain/repository/NotificationRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.notification.domain.entity.Notification;
 import com.campus.campus.domain.user.domain.entity.User;
 
@@ -32,4 +33,22 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 	);
 
 	boolean existsByUser_IdAndIsReadFalse(Long userId);
+
+	List<Notification> findByStudentCouncilOrderByCreatedAtDescIdDesc(StudentCouncil council, Pageable pageable);
+
+	@Query("""
+			select n from Notification n
+			where n.studentCouncil = :council
+			  and (
+			       n.createdAt < :cursorCreatedAt
+			    or (n.createdAt = :cursorCreatedAt and n.id < :cursorId)
+			  )
+			order by n.createdAt desc, n.id desc
+		""")
+	List<Notification> findNextByCouncilCursor(
+		@Param("council") StudentCouncil council,
+		@Param("cursorCreatedAt") LocalDateTime cursorCreatedAt,
+		@Param("cursorId") Long cursorId,
+		Pageable pageable
+	);
 }

--- a/src/main/java/com/campus/campus/domain/notification/presentation/StudentCouncilNotificationController.java
+++ b/src/main/java/com/campus/campus/domain/notification/presentation/StudentCouncilNotificationController.java
@@ -61,4 +61,18 @@ public class StudentCouncilNotificationController {
 		councilNotificationService.markCouncilNotificationAsRead(councilId, notificationId);
 		return CommonResponse.success(NotificationResponseCode.NOTIFICATION_READ_SUCCESS);
 	}
+
+	@GetMapping("/unread/exists")
+	@Operation(
+		summary = "학생회 미확인 알림 여부 확인",
+		description = "학생회 홈에서 미확인 알림이 있는지 확인하여 빨간 점 등을 표시합니다."
+	)
+	public CommonResponse<Boolean> hasUnread(@CurrentCouncilId Long councilId) {
+		boolean hasUnread = councilNotificationService.hasCouncilUnread(councilId);
+
+		return CommonResponse.success(
+			NotificationResponseCode.NOTIFICATION_UNREAD_EXISTS_SUCCESS,
+			hasUnread
+		);
+	}
 }

--- a/src/main/java/com/campus/campus/domain/notification/presentation/StudentCouncilNotificationController.java
+++ b/src/main/java/com/campus/campus/domain/notification/presentation/StudentCouncilNotificationController.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -45,5 +47,18 @@ public class StudentCouncilNotificationController {
 			councilNotificationService.getCouncilNotificationsByCursor(councilId, cursorCreatedAt, cursorId, limit);
 
 		return CommonResponse.success(NotificationResponseCode.NOTIFICATION_READ_SUCCESS, response);
+	}
+
+	@PatchMapping("/{notificationId}/read")
+	@Operation(
+		summary = "학생회 특정 알림 읽음 처리",
+		description = "학생회 알림을 읽음 상태로 변경합니다."
+	)
+	public CommonResponse<Void> markAsRead(
+		@PathVariable Long notificationId,
+		@CurrentCouncilId Long councilId
+	) {
+		councilNotificationService.markCouncilNotificationAsRead(councilId, notificationId);
+		return CommonResponse.success(NotificationResponseCode.NOTIFICATION_READ_SUCCESS);
 	}
 }

--- a/src/main/java/com/campus/campus/domain/notification/presentation/StudentCouncilNotificationController.java
+++ b/src/main/java/com/campus/campus/domain/notification/presentation/StudentCouncilNotificationController.java
@@ -1,0 +1,49 @@
+package com.campus.campus.domain.notification.presentation;
+
+import java.time.LocalDateTime;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.campus.campus.domain.notification.application.dto.CursorResponse;
+import com.campus.campus.domain.notification.application.dto.NotificationResponse;
+import com.campus.campus.domain.notification.application.service.StudentCouncilNotificationService;
+import com.campus.campus.global.annotation.CurrentCouncilId;
+import com.campus.campus.global.common.response.CommonResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequestMapping("/student-councils/notifications")
+@RequiredArgsConstructor
+@Tag(name = "학생회 알림", description = "학생회 전용 알림 관련 API")
+public class StudentCouncilNotificationController {
+
+	private final StudentCouncilNotificationService councilNotificationService;
+
+	@GetMapping
+	@Operation(
+		summary = "학생회 알림 목록 조회",
+		description = "학생회 계정의 알림 목록을 최신순으로 조회합니다. (커서 기반 페이징)"
+	)
+	public CommonResponse<CursorResponse<NotificationResponse>> getCouncilNotifications(
+		@RequestParam(defaultValue = "20") int limit,
+		@RequestParam(required = false)
+		@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+		LocalDateTime cursorCreatedAt,
+		@RequestParam(required = false) Long cursorId,
+		@CurrentCouncilId Long councilId
+	) {
+		CursorResponse<NotificationResponse> response =
+			councilNotificationService.getCouncilNotificationsByCursor(councilId, cursorCreatedAt, cursorId, limit);
+
+		return CommonResponse.success(NotificationResponseCode.NOTIFICATION_READ_SUCCESS, response);
+	}
+}


### PR DESCRIPTION
## 🔀 변경 내용
- 학생회(StudentCouncil) 알림 수신 구조 구축: Notification 엔티티에 student_council_id 연관관계를 추가하여 일반 유저와 학생회 운영진 모두 알림을 받을 수 있는 다중 FK 구조를 설계했습니다.
- 문의 답변 알림 자동화: 관리자가 문의사항에 답변을 등록할 때, 작성자 타입(유저/학생회)을 자동으로 식별하여 "문의하신 내용에 답변이 도착했어요."라는 시스템 알림이 발송되도록 로직을 연동했습니다.
- 학생회 전용 알림 API 신설: 학생회 운영진이 본인들의 알림 목록을 확인하고, 읽음 처리 및 미확인 알림 존재 여부(빨간 점)를 확인할 수 있는 전용 컨트롤러와 서비스를 구현했습니다.

## ✅ 작업 항목
- [x] Notification 엔티티 확장 (StudentCouncil 연관관계 추가)
- [x] 학생회용 알림 목록 조회 및 커서 기반 페이징 구현
- [x] StudentCouncilNotificationController 및 서비스 구현
- [x] 문의 답변 완료 시 수신자 맞춤형 알림 발송 로직 연동

## 📸 스크린샷 (선택)

## 📎 참고 이슈
관련 이슈 번호 #110 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 문의 답변 시 작성자 또는 학생회에 자동 알림 발송 기능 추가.
  * 학생회 대상 알림 생성·저장 및 커서 기반 조회 기능 추가.
  * 학생회 전용 알림의 읽음 처리 및 미읽음 확인 기능 추가.

* **개선**
  * 알림 발송 과정에 로깅 및 예외 처리 추가로 안정성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->