### PR TITLE
feat/#114: 기획 변경에 따른 장소 조회 API 로직 일괄 변경

### DIFF
--- a/src/main/java/com/campus/campus/domain/councilpost/domain/repository/PostImageRepository.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/repository/PostImageRepository.java
@@ -1,6 +1,7 @@
 package com.campus.campus.domain.councilpost.domain.repository;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -26,4 +27,12 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long> {
 	List<String> findImageUrlsByPost(@Param("post") StudentCouncilPost post);
 
 	List<PostImage> findAllByPostIn(List<StudentCouncilPost> posts);
+
+	@Query("""
+		SELECT pi.post.id, pi.imageUrl
+		FROM PostImage pi
+		WHERE pi.post.id IN :postIds
+		ORDER BY pi.id ASC
+		""")
+	List<Object[]> findImageUrlsByPostIds(@Param("postIds") Set<Long> postIds);
 }

--- a/src/main/java/com/campus/campus/domain/councilpost/domain/repository/StudentCouncilPostRepository.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/domain/repository/StudentCouncilPostRepository.java
@@ -319,14 +319,28 @@ public interface StudentCouncilPostRepository extends JpaRepository<StudentCounc
 		    FROM StudentCouncilPost p
 		    JOIN p.writer w
 		    JOIN p.place pl
+		    LEFT JOIN w.school s
+		    LEFT JOIN w.college c
+		    LEFT JOIN w.major m
 		    WHERE pl.placeKey IN :placeKeys
 		      AND p.category = 'PARTNERSHIP'
 		      AND :now BETWEEN p.startDateTime AND p.endDateTime
 		      AND w.deletedAt IS NULL
+		      AND (
+		           (w.councilType = :majorType AND m.majorId = :majorId)
+		        OR (w.councilType = :collegeType AND c.collegeId = :collegeId)
+		        OR (w.councilType = :schoolType AND s.schoolId = :schoolId)
+		      )
 		""")
 	List<Object[]> findActivePartnershipsByPlaceKeys(
 		@Param("placeKeys") List<String> placeKeys,
-		@Param("now") LocalDateTime now
+		@Param("now") LocalDateTime now,
+		@Param("majorId") Long majorId,
+		@Param("collegeId") Long collegeId,
+		@Param("schoolId") Long schoolId,
+		@Param("majorType") CouncilType majorType,
+		@Param("collegeType") CouncilType collegeType,
+		@Param("schoolType") CouncilType schoolType
 	);
 
 	@EntityGraph(attributePaths = {"writer", "writer.school", "writer.college", "writer.major", "place"})

--- a/src/main/java/com/campus/campus/domain/place/application/dto/response/SearchPlaceInfoResponse.java
+++ b/src/main/java/com/campus/campus/domain/place/application/dto/response/SearchPlaceInfoResponse.java
@@ -8,6 +8,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 public record SearchPlaceInfoResponse(
+	@Schema(description = "DB 장소 ID (미저장 시 null)", example = "42")
+	Long placeId,
+
 	@Schema(description = "해당 장소명", example = "숙명여자대학교")
 	@NotBlank
 	String placeName,

--- a/src/main/java/com/campus/campus/domain/place/application/mapper/PlaceMapper.java
+++ b/src/main/java/com/campus/campus/domain/place/application/mapper/PlaceMapper.java
@@ -57,6 +57,7 @@ public class PlaceMapper {
 	public SearchPlaceInfoResponse toSearchPlaceInfoResponse(SavedPlaceInfo savedPlaceInfo, boolean isLiked,
 		List<SearchPartnershipInfoResponse> partnerships, Double averageStar) {
 		return new SearchPlaceInfoResponse(
+			savedPlaceInfo.placeId(),
 			savedPlaceInfo.placeName(),
 			savedPlaceInfo.placeKey(),
 			savedPlaceInfo.address(),

--- a/src/main/java/com/campus/campus/domain/place/application/mapper/PlaceMapper.java
+++ b/src/main/java/com/campus/campus/domain/place/application/mapper/PlaceMapper.java
@@ -55,7 +55,7 @@ public class PlaceMapper {
 	}
 
 	public SearchPlaceInfoResponse toSearchPlaceInfoResponse(SavedPlaceInfo savedPlaceInfo, boolean isLiked,
-		List<SearchPartnershipInfoResponse> partnerships, Double averageStar) {
+		List<SearchPartnershipInfoResponse> partnerships, Double averageStar, List<String> imgUrls) {
 		return new SearchPlaceInfoResponse(
 			savedPlaceInfo.placeId(),
 			savedPlaceInfo.placeName(),
@@ -65,7 +65,7 @@ public class PlaceMapper {
 			savedPlaceInfo.link(),
 			savedPlaceInfo.telephone(),
 			savedPlaceInfo.coordinate(),
-			savedPlaceInfo.imgUrls(),
+			imgUrls,
 			isLiked,
 			partnerships,
 			averageStar

--- a/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
+++ b/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
@@ -178,7 +178,7 @@ public class PlaceService {
 
 		Map<Long, String> reviewImageMap = nonPartnershipPlaceIds.isEmpty()
 			? Collections.emptyMap()
-			: reviewImageRepository.findFirstImageUrlsByPlaceIds(nonPartnershipPlaceIds).stream()
+			: reviewImageRepository.findOldestImageUrlsByPlaceIds(nonPartnershipPlaceIds).stream()
 				.collect(Collectors.toMap(obj -> (Long)obj[0], obj -> (String)obj[1]));
 
 		return basicResults.stream()

--- a/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
+++ b/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
@@ -51,6 +51,7 @@ import com.campus.campus.domain.place.domain.repository.CouncilPartnershipSugges
 import com.campus.campus.domain.place.domain.repository.LikedPlacesRepository;
 import com.campus.campus.domain.place.domain.repository.PlaceRepository;
 import com.campus.campus.domain.place.domain.repository.UserPartnershipSuggestionRepository;
+import com.campus.campus.domain.councilpost.domain.repository.PostImageRepository;
 import com.campus.campus.domain.place.infrastructure.kakao.KakaoLocalClient;
 import com.campus.campus.domain.review.application.dto.response.SimpleReviewResponse;
 import com.campus.campus.domain.review.application.mapper.ReviewMapper;
@@ -94,6 +95,7 @@ public class PlaceService {
 	private final CouncilPartnershipSuggestionRepository partnershipSuggestionRepository;
 	private final StudentCouncilRepository studentCouncilRepository;
 	private final ReviewImageRepository reviewImageRepository;
+	private final PostImageRepository postImageRepository;
 	private final ReviewMapper reviewMapper;
 
 	public List<SavedPlaceInfo> searchByLocationAndKeyword(double lat, double lng, String keyword, int imageLimit) {
@@ -140,11 +142,58 @@ public class PlaceService {
 				)
 			));
 
+		// 제휴 장소 이미지: postId → List<imageUrl>
+		Set<Long> postIds = partnershipMap.values().stream()
+			.flatMap(List::stream)
+			.map(SearchPartnershipInfoResponse::postId)
+			.collect(Collectors.toSet());
+
+		Map<Long, List<String>> postImageMap = postIds.isEmpty()
+			? Collections.emptyMap()
+			: postImageRepository.findImageUrlsByPostIds(postIds).stream()
+				.collect(Collectors.groupingBy(
+					obj -> (Long)obj[0],
+					Collectors.mapping(obj -> (String)obj[1], Collectors.toList())
+				));
+
+		// 비제휴 DB 장소 이미지: placeId → imageUrl (1장)
+		Set<Long> nonPartnershipPlaceIds = basicResults.stream()
+			.filter(info -> info.placeId() != null && !partnershipMap.containsKey(info.placeKey()))
+			.map(SavedPlaceInfo::placeId)
+			.collect(Collectors.toSet());
+
+		Map<Long, String> reviewImageMap = nonPartnershipPlaceIds.isEmpty()
+			? Collections.emptyMap()
+			: reviewImageRepository.findFirstImageUrlsByPlaceIds(nonPartnershipPlaceIds).stream()
+				.collect(Collectors.toMap(obj -> (Long)obj[0], obj -> (String)obj[1]));
+
 		return basicResults.stream()
-			.map(info -> placeMapper.toSearchPlaceInfoResponse(
-				info, likedKeys.contains(info.placeKey()), partnershipMap.getOrDefault(info.placeKey(), List.of()),
-				Math.round(starMap.getOrDefault(info.placeKey(), 0.0) * 10.0) / 10.0
-			))
+			.map(info -> {
+				List<SearchPartnershipInfoResponse> partnerships = partnershipMap.getOrDefault(info.placeKey(),
+					List.of());
+
+				List<String> imgUrls;
+				if (!partnerships.isEmpty()) {
+					// 제휴 장소 → PostImage 전체
+					imgUrls = partnerships.stream()
+						.map(SearchPartnershipInfoResponse::postId)
+						.flatMap(postId -> postImageMap.getOrDefault(postId, List.of()).stream())
+						.toList();
+				} else if (info.placeId() != null) {
+					// DB 장소 → ReviewImage 1장
+					String reviewImgUrl = reviewImageMap.get(info.placeId());
+					imgUrls = reviewImgUrl != null ? List.of(reviewImgUrl) : List.of();
+				} else {
+					// 미저장 장소 → 빈 배열
+					imgUrls = List.of();
+				}
+
+				return placeMapper.toSearchPlaceInfoResponse(
+					info, likedKeys.contains(info.placeKey()), partnerships,
+					Math.round(starMap.getOrDefault(info.placeKey(), 0.0) * 10.0) / 10.0,
+					imgUrls
+				);
+			})
 			.toList();
 	}
 

--- a/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
+++ b/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
@@ -106,8 +106,8 @@ public class PlaceService {
 	}
 
 	public List<SearchPlaceInfoResponse> searchByLocationAndKeywordWithInfo(Long userId, double lat, double lng,
-		String keyword, int imageLimit) {
-		List<SavedPlaceInfo> basicResults = searchByLocationAndKeyword(lat, lng, keyword, imageLimit);
+		String keyword) {
+		List<SavedPlaceInfo> basicResults = searchByLocationAndKeyword(lat, lng, keyword, 0);
 
 		if (basicResults.isEmpty()) {
 			return List.of();

--- a/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
+++ b/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
@@ -101,7 +101,7 @@ public class PlaceService {
 	public List<SavedPlaceInfo> searchByLocationAndKeyword(double lat, double lng, String keyword, int imageLimit) {
 		log.info("카카오 좌표 기반 검색: lat={}, lng={}, keyword={}", lat, lng, keyword);
 
-		KakaoSearchResponse kakaoSearchResponse = kakaoLocalClient.searchPlaces(keyword, lat, lng, 2000, 5);
+		KakaoSearchResponse kakaoSearchResponse = kakaoLocalClient.searchPlaces(keyword, lat, lng, 1500);
 		return processSearchResults(kakaoSearchResponse);
 	}
 
@@ -211,7 +211,7 @@ public class PlaceService {
 			.toList();
 	}
 
-	public List<SavedPlaceInfo> searchByKeyword(String keyword, int imageLimit) {
+	public List<SavedPlaceInfo> searchByKeyword(String keyword) {
 		KakaoSearchResponse kakaoSearchResponse = kakaoLocalClient.searchPlaces(keyword, 5);
 
 		return processSearchResults(kakaoSearchResponse);

--- a/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
+++ b/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
@@ -132,15 +132,29 @@ public class PlaceService {
 				})
 			);
 
-		Map<String, List<SearchPartnershipInfoResponse>> partnershipMap = studentCouncilPostRepository
-			.findActivePartnershipsByPlaceKeys(placeKeys, LocalDateTime.now(KST)).stream()
-			.collect(Collectors.groupingBy(
-				obj -> (String)obj[0],
-				Collectors.mapping(
-					obj -> new SearchPartnershipInfoResponse((Long)obj[3], (String)obj[1], (String)obj[2]),
-					Collectors.toList()
-				)
-			));
+		Map<String, List<SearchPartnershipInfoResponse>> partnershipMap;
+		if (userId != null) {
+			User user = userRepository.findById(userId)
+				.orElseThrow(UserNotFoundException::new);
+			Long schoolId = user.getSchool() != null ? user.getSchool().getSchoolId() : null;
+			Long collegeId = user.getCollege() != null ? user.getCollege().getCollegeId() : null;
+			Long majorId = user.getMajor() != null ? user.getMajor().getMajorId() : null;
+
+			partnershipMap = studentCouncilPostRepository
+				.findActivePartnershipsByPlaceKeys(placeKeys, LocalDateTime.now(KST),
+					majorId, collegeId, schoolId,
+					CouncilType.MAJOR_COUNCIL, CouncilType.COLLEGE_COUNCIL, CouncilType.SCHOOL_COUNCIL)
+				.stream()
+				.collect(Collectors.groupingBy(
+					obj -> (String)obj[0],
+					Collectors.mapping(
+						obj -> new SearchPartnershipInfoResponse((Long)obj[3], (String)obj[1], (String)obj[2]),
+						Collectors.toList()
+					)
+				));
+		} else {
+			partnershipMap = Collections.emptyMap();
+		}
 
 		// 제휴 장소 이미지: postId → List<imageUrl>
 		Set<Long> postIds = partnershipMap.values().stream()

--- a/src/main/java/com/campus/campus/domain/place/infrastructure/kakao/KakaoLocalClient.java
+++ b/src/main/java/com/campus/campus/domain/place/infrastructure/kakao/KakaoLocalClient.java
@@ -26,7 +26,7 @@ public class KakaoLocalClient {
 	/**
 	 * 좌표 기반 키워드 장소 검색
 	 */
-	public KakaoSearchResponse searchPlaces(String keyword, double lat, double lng, int radius, int count) {
+	public KakaoSearchResponse searchPlaces(String keyword, double lat, double lng, int radius) {
 		KakaoSearchResponse response = restClient.get()
 				.uri(uriBuilder -> uriBuilder.scheme("https")
 						.host("dapi.kakao.com")
@@ -35,7 +35,6 @@ public class KakaoLocalClient {
 						.queryParam("y", lat)
 						.queryParam("x", lng)
 						.queryParam("radius", radius)
-						.queryParam("size", count)
 						.queryParam("sort", "distance")
 						.build())
 				.header("Authorization", "KakaoAK " + apiKey)

--- a/src/main/java/com/campus/campus/domain/place/presentation/PlaceController.java
+++ b/src/main/java/com/campus/campus/domain/place/presentation/PlaceController.java
@@ -69,7 +69,7 @@ public class PlaceController {
 	@GetMapping("/search/keyword")
 	@Operation(summary = "키워드 기반 장소 검색")
 	public CommonResponse<List<SavedPlaceInfo>> getPlaceInfoWithKeyword(@RequestParam String keyword) {
-		List<SavedPlaceInfo> searchResponse = placeService.searchByKeyword(keyword, 3);
+		List<SavedPlaceInfo> searchResponse = placeService.searchByKeyword(keyword);
 
 		return CommonResponse.success(PlaceResponseCode.PLACE_SEARCH_SUCCESS, searchResponse);
 	}

--- a/src/main/java/com/campus/campus/domain/place/presentation/PlaceController.java
+++ b/src/main/java/com/campus/campus/domain/place/presentation/PlaceController.java
@@ -39,8 +39,9 @@ public class PlaceController {
 	private final PartnershipPlaceService partnershipPlaceService;
 	private final GeoCoderClient geoCoderClient;
 
+	@Deprecated
 	@GetMapping("/search")
-	@Operation(summary = "현위치 기반 가까운 순으로 장소 키워드 검색", description = "검색 결과 5개 검색되도록 함")
+	@Operation(summary = "현위치 기반 가까운 순으로 장소 키워드 검색", description = "GET /places/search/info 로 대체됨", deprecated = true)
 	public CommonResponse<List<SavedPlaceInfo>> getPlaceWithLocationAndKeyword(
 		@Parameter(description = "검색할 키워드", example = "스타벅스") @RequestParam String keyword,
 		@Parameter(description = "현재 위치의 위도", example = "37.50415") @RequestParam double lat,
@@ -198,10 +199,12 @@ public class PlaceController {
 		return CommonResponse.success(PlaceResponseCode.PARTNERSHIP_SUGGEST_SUCCESS);
 	}
 
+	@Deprecated
 	@GetMapping("/search/detailed")
 	@Operation(
 		summary = "키워드 기반 장소 상세 검색 (제휴/리뷰/좋아요 정보 포함)",
-		description = "키워드로 장소를 검색하며, DB에 데이터가 있는 경우 리뷰, 별점, 제휴 정보를 함께 반환합니다."
+		description = "GET /places/search/info + GET /reviews/list/{placeId} 조합으로 대체됨",
+		deprecated = true
 	)
 	public CommonResponse<List<PartnershipDetailResponse>> searchDetailedPlaces(
 		@Parameter(description = "검색할 키워드", example = "스타벅스") @RequestParam String keyword,

--- a/src/main/java/com/campus/campus/domain/place/presentation/PlaceController.java
+++ b/src/main/java/com/campus/campus/domain/place/presentation/PlaceController.java
@@ -61,7 +61,7 @@ public class PlaceController {
 		@CurrentUserId(required = false) Long userId
 	) {
 		List<SearchPlaceInfoResponse> searchResponse = placeService.searchByLocationAndKeywordWithInfo(userId, lat, lng,
-			keyword, 3);
+			keyword);
 
 		return CommonResponse.success(PlaceResponseCode.PLACE_SEARCH_SUCCESS, searchResponse);
 	}

--- a/src/main/java/com/campus/campus/domain/review/domain/repository/ReviewImageRepository.java
+++ b/src/main/java/com/campus/campus/domain/review/domain/repository/ReviewImageRepository.java
@@ -1,8 +1,10 @@
 package com.campus.campus.domain.review.domain.repository;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.campus.campus.domain.review.domain.entity.Review;
@@ -17,5 +19,13 @@ public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> 
 	List<ReviewImage> findAllByReview(Review review);
 
 	void deleteByReview(Review review);
+
+	@Query("""
+		SELECT ri.review.place.placeId, MIN(ri.imageUrl)
+		FROM ReviewImage ri
+		WHERE ri.review.place.placeId IN :placeIds
+		GROUP BY ri.review.place.placeId
+		""")
+	List<Object[]> findFirstImageUrlsByPlaceIds(@Param("placeIds") Set<Long> placeIds);
 
 }

--- a/src/main/java/com/campus/campus/domain/review/domain/repository/ReviewImageRepository.java
+++ b/src/main/java/com/campus/campus/domain/review/domain/repository/ReviewImageRepository.java
@@ -21,11 +21,15 @@ public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> 
 	void deleteByReview(Review review);
 
 	@Query("""
-		SELECT ri.review.place.placeId, MIN(ri.imageUrl)
+		SELECT ri.review.place.placeId, ri.imageUrl
 		FROM ReviewImage ri
 		WHERE ri.review.place.placeId IN :placeIds
-		GROUP BY ri.review.place.placeId
+		  AND ri.id = (
+		    SELECT MIN(ri2.id)
+		    FROM ReviewImage ri2
+		    WHERE ri2.review.place.placeId = ri.review.place.placeId
+		  )
 		""")
-	List<Object[]> findFirstImageUrlsByPlaceIds(@Param("placeIds") Set<Long> placeIds);
+	List<Object[]> findOldestImageUrlsByPlaceIds(@Param("placeIds") Set<Long> placeIds);
 
 }

--- a/src/main/java/com/campus/campus/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/campus/campus/global/config/PermitUrlConfig.java
@@ -30,6 +30,7 @@ public class PermitUrlConfig {
 			"/jwt/token/reissue",
 			"/managers/login",
 			"/places/search",
+			"/places/search/info",
 			"/storage/presigned",
 			"/places",
 			"/api/partnership/list",


### PR DESCRIPTION
## 🔀 변경 내용
- 어떤 기능을 구현하거나 수정했는지 간단히 요약해주세요.

1. placeId 필드 추가 — SearchPlaceInfoResponse에 placeId 추가. 클라이언트가 리뷰 조회(GET /reviews/list/{placeId}) 가능하도록 함
2. 이미지 정책 적용 — 기존에 항상 빈 배열이던 imgUrls에 실제 이미지 반영
  - 제휴 장소 → PostImage 전체 (여러장)
  - DB 저장 장소 → ReviewImage 1장
  - 미저장 장소 → 빈 배열
3. 제휴 조회에 학적 범위 필터 추가 — 사용자의 학교/단과대/학과 범위에 해당하는 제휴만 노출.
비로그인 시 제휴 정보 빈 리스트 반환
4. 미사용 imageLimit 파라미터 제거 — 서비스/컨트롤러에서 사용되지 않던 imageLimit 파라미터 정리

## 📸 스크린샷 (선택)

## 📎 참고 이슈
관련 이슈 번호#114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 장소 검색 응답에 DB 장소 ID(placeId) 포함 및 추가 검색 정보 엔드포인트("/places/search/info") 제공

* **Improvements**
  * 검색 결과에 게시글·리뷰 기반 이미지 노출 개선으로 이미지 품질 및 일관성 향상
  * 카카오 검색 반경을 좁혀(2000→1500m) 더 관련성 높은 장소 제공
  * 파트너십 기반 검색 필터링 범위 확장으로 관련 장소 노출 강화

* **Deprecations**
  * 기존 장소 검색 엔드포인트(/places/search, /places/search/detailed) 비활성화 표시 (대체 엔드포인트 사용 권장)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->