### PR TITLE
feat/#116: add dev-only user login endpoint

### DIFF
--- a/src/main/java/com/campus/campus/domain/user/presentation/DevAuthController.java
+++ b/src/main/java/com/campus/campus/domain/user/presentation/DevAuthController.java
@@ -1,0 +1,54 @@
+package com.campus.campus.domain.user.presentation;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.campus.campus.domain.user.application.exception.UserNotFoundException;
+import com.campus.campus.domain.user.domain.entity.User;
+import com.campus.campus.domain.user.domain.repository.UserRepository;
+import com.campus.campus.global.auth.application.dto.OauthLoginResponse;
+import com.campus.campus.global.auth.application.mapper.LoginMapper;
+import com.campus.campus.global.common.response.CommonResponse;
+import com.campus.campus.global.util.jwt.JwtProvider;
+import com.campus.campus.global.util.jwt.application.service.RedisTokenService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Value;
+
+@Profile({"local", "dev"})
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/dev")
+@Tag(name = "Dev 전용", description = "개발 환경 전용 API (local, dev 프로파일에서만 동작)")
+public class DevAuthController {
+
+	private final UserRepository userRepository;
+	private final JwtProvider jwtProvider;
+	private final RedisTokenService redisTokenService;
+	private final LoginMapper loginMapper;
+
+	@Value("${jwt.refresh.expiration-seconds}")
+	private long refreshTokenExpirationSeconds;
+
+	@PostMapping("/login")
+	@Operation(summary = "Dev 전용 유저 로그인", description = "userId만으로 JWT 토큰을 발급합니다. 카카오 OAuth 없이 테스트용으로 사용합니다.")
+	public CommonResponse<OauthLoginResponse> devLogin(@RequestParam("userId") Long userId) {
+		User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+			.orElseThrow(UserNotFoundException::new);
+
+		String accessToken = jwtProvider.createAccessToken(user.getId());
+		String refreshToken = jwtProvider.createRefreshToken(user.getId());
+
+		redisTokenService.setRefreshToken("USER", String.valueOf(user.getId()), refreshToken,
+			refreshTokenExpirationSeconds);
+
+		return CommonResponse.success(UserResponseCode.LOGIN_SUCCESS,
+			loginMapper.toOauthLoginResponse(user, accessToken, refreshToken));
+	}
+}

--- a/src/main/java/com/campus/campus/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/campus/campus/global/config/PermitUrlConfig.java
@@ -35,6 +35,7 @@ public class PermitUrlConfig {
 			"/places",
 			"/api/partnership/list",
 			"/api/partnership/map",
+			// TODO: main 브랜치 머지 전 반드시 제거 — dev 전용 엔드포인트
 			"/dev/**"
 		};
 	}

--- a/src/main/java/com/campus/campus/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/campus/campus/global/config/PermitUrlConfig.java
@@ -34,7 +34,8 @@ public class PermitUrlConfig {
 			"/storage/presigned",
 			"/places",
 			"/api/partnership/list",
-			"/api/partnership/map"
+			"/api/partnership/map",
+			"/dev/**"
 		};
 	}
 }


### PR DESCRIPTION
## 🔀 변경 내용
- 어떤 기능을 구현하거나 수정했는지 간단히 요약해주세요.

dev에서 사용할 user 로그인 endpoint (카카오 로그인 우회 용도)

## 📎 참고 이슈
관련 이슈 번호#116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 개발 환경용 로그인 엔드포인트 추가 (로컬/개발 프로필에서만 활성화)
  * 개발용 엔드포인트를 통해 액세스/리프레시 토큰 발급 및 로그인 응답 제공
  * 개발용 API가 공개 경로에 포함되어 개발 환경에서 접근 가능하도록 구성
  * 개발용 엔드포인트에 대한 API 문서 메타데이터 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->