### PR TITLE
[FIX] 카카오 로그인 accessToken 기반 처리로 수정 (#128)

### DIFF
--- a/src/main/java/com/campus/campus/domain/user/application/service/KakaoOauthService.java
+++ b/src/main/java/com/campus/campus/domain/user/application/service/KakaoOauthService.java
@@ -16,7 +16,6 @@ import com.campus.campus.domain.user.application.exception.UserSignupForbiddenEx
 import com.campus.campus.domain.user.application.mapper.UserMapper;
 import com.campus.campus.domain.user.domain.entity.User;
 import com.campus.campus.domain.user.domain.repository.UserRepository;
-import com.campus.campus.global.auth.application.dto.KakaoTokenResponse;
 import com.campus.campus.global.auth.application.dto.KakaoUserResponse;
 import com.campus.campus.global.auth.application.dto.OauthLoginResponse;
 import com.campus.campus.global.auth.application.mapper.LoginMapper;
@@ -46,9 +45,8 @@ public class KakaoOauthService {
 	private long refreshTokenExpirationSeconds;
 
 	@Transactional
-	public OauthLoginResponse login(String authorizationCode) {
-		KakaoTokenResponse kakaoToken = getToken(authorizationCode);
-		KakaoUserResponse kakaoUser = getUserInfo(kakaoToken.accessToken());
+	public OauthLoginResponse login(String kakaoAccessToken) {
+		KakaoUserResponse kakaoUser = getUserInfo(kakaoAccessToken);
 
 		User user = findOrCreateUser(kakaoUser);
 
@@ -132,27 +130,5 @@ public class KakaoOauthService {
 				User newUser = userMapper.createUser(kakaoId, nickname, email, profileImage);
 				return userRepository.save(newUser);
 			});
-	}
-
-	private KakaoTokenResponse getToken(String authorizationCode) {
-		RestClient client = RestClient.create();
-
-		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
-		body.add("grant_type", "authorization_code");
-		body.add("client_id", kakaoOauthProperty.getClientId());
-		body.add("redirect_uri", kakaoOauthProperty.getRedirectUri());
-		body.add("code", authorizationCode);
-
-		if (kakaoOauthProperty.getClientSecret() != null &&
-			!kakaoOauthProperty.getClientSecret().isBlank()) {
-			body.add("client_secret", kakaoOauthProperty.getClientSecret());
-		}
-
-		return client.post()
-			.uri(KAUTH_BASE_URL + "/oauth/token")
-			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
-			.body(body)
-			.retrieve()
-			.body(KakaoTokenResponse.class);
 	}
 }


### PR DESCRIPTION
## 🔀 변경 내용
- 카카오 로그인 처리 방식을 authorization code 기반 → accessToken 기반으로 변경했습니다.

## ✅ 작업 항목
- [x] KakaoOauthService에서 authorization code 기반 토큰 재발급 로직 제거
- [x] accessToken 기반 사용자 정보 조회 로직으로 변경

## 📸 스크린샷 (선택)

## 📎 참고 이슈
Closes #128 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **개선사항**
  * 카카오 로그인 프로세스를 간소화했습니다. 로그인 요청이 더 효율적으로 처리되도록 개선되어 사용자 인증 절차가 신속하게 진행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->