### PR TITLE
feat/#126: 알림 조회 시, 학생회 프로필 이미지 추가

### DIFF
--- a/src/main/java/com/campus/campus/domain/councilpost/application/CouncilPostPushListener.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/CouncilPostPushListener.java
@@ -38,7 +38,7 @@ public class CouncilPostPushListener {
 		log.info("[PUSH] after_commit event received. topic={}, postId={}, category={}",
 			event.topic(), event.postId(), event.category());
 
-		notificationService.savePostCreatedNotification(event, title, body);
+		notificationService.savePostCreatedNotification(event, title, body, event.studentCouncil());
 
 		firebaseCloudMessageService.sendToTopic(
 			event.topic(),

--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/request/CouncilPostCreatedEvent.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/request/CouncilPostCreatedEvent.java
@@ -12,7 +12,6 @@ public record CouncilPostCreatedEvent(
 	@Schema(description = "학생회 이름", example = "중앙대학교 총학생회")
 	String councilName,
 
-	@Schema(description = "학생회 id", example = "1")
 	StudentCouncil studentCouncil,
 
 	@Schema(description = "게시글 카테고리", example = "EVENT")

--- a/src/main/java/com/campus/campus/domain/councilpost/application/dto/request/CouncilPostCreatedEvent.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/dto/request/CouncilPostCreatedEvent.java
@@ -1,5 +1,6 @@
 package com.campus.campus.domain.councilpost.application.dto.request;
 
+import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.councilpost.domain.entity.PostCategory;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -10,6 +11,9 @@ public record CouncilPostCreatedEvent(
 
 	@Schema(description = "학생회 이름", example = "중앙대학교 총학생회")
 	String councilName,
+
+	@Schema(description = "학생회 id", example = "1")
+	StudentCouncil studentCouncil,
 
 	@Schema(description = "게시글 카테고리", example = "EVENT")
 	PostCategory category,

--- a/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
+++ b/src/main/java/com/campus/campus/domain/councilpost/application/mapper/StudentCouncilPostMapper.java
@@ -233,6 +233,7 @@ public class StudentCouncilPostMapper {
 		return new CouncilPostCreatedEvent(
 			post.getId(),
 			writer.getCouncilName(),
+			writer,
 			post.getCategory(),
 			topic
 		);

--- a/src/main/java/com/campus/campus/domain/notification/application/dto/NotificationResponse.java
+++ b/src/main/java/com/campus/campus/domain/notification/application/dto/NotificationResponse.java
@@ -1,6 +1,7 @@
 package com.campus.campus.domain.notification.application.dto;
 
 import com.campus.campus.domain.notification.domain.entity.NotificationType;
+import com.campus.campus.domain.notification.domain.entity.SenderType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -16,6 +17,12 @@ public record NotificationResponse(
 
 	@Schema(description = "알림 내용", example = "새 행사글이 등록되었습니다.")
 	String body,
+
+	@Schema(description = "보낸 주체 타입", example = "COUNCIL")
+	SenderType senderType,
+
+	@Schema(description = "보낸 주체 프로필 이미지 URL", example = "https://cdn.example.com/council/profile.png")
+	String profileImageUrl,
 
 	@Schema(description = "참조 ID (게시글 ID 등)", example = "123")
 	Long referenceId,

--- a/src/main/java/com/campus/campus/domain/notification/application/dto/NotificationResponse.java
+++ b/src/main/java/com/campus/campus/domain/notification/application/dto/NotificationResponse.java
@@ -18,7 +18,7 @@ public record NotificationResponse(
 	@Schema(description = "알림 내용", example = "새 행사글이 등록되었습니다.")
 	String body,
 
-	@Schema(description = "보낸 주체 타입", example = "COUNCIL")
+	@Schema(description = "보낸 주체 타입", example = "STUDENT_COUNCIL")
 	SenderType senderType,
 
 	@Schema(description = "보낸 주체 프로필 이미지 URL", example = "https://cdn.example.com/council/profile.png")

--- a/src/main/java/com/campus/campus/domain/notification/application/mapper/NotificationMapper.java
+++ b/src/main/java/com/campus/campus/domain/notification/application/mapper/NotificationMapper.java
@@ -1,11 +1,14 @@
 package com.campus.campus.domain.notification.application.mapper;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Component;
 
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.notification.application.dto.NotificationResponse;
 import com.campus.campus.domain.notification.domain.entity.Notification;
 import com.campus.campus.domain.notification.domain.entity.NotificationType;
+import com.campus.campus.domain.notification.domain.entity.SenderType;
 import com.campus.campus.domain.notification.util.TimeFormatter;
 import com.campus.campus.domain.user.domain.entity.User;
 
@@ -18,21 +21,36 @@ public class NotificationMapper {
 	private final TimeFormatter timeFormatter;
 
 	public NotificationResponse toResponse(Notification notification) {
+
+		String senderProfileImage;
+		SenderType senderType;
+
+		if (notification.getStudentCouncil() != null) {
+			senderType = SenderType.STUDENT_COUNCIL;
+			senderProfileImage = notification.getStudentCouncil().getCouncilProfileImageUrl();
+		} else {
+			senderType = SenderType.SYSTEM;
+			senderProfileImage = null;
+		}
+
 		return new NotificationResponse(
 			notification.getId(),
 			notification.getType(),
 			notification.getTitle(),
 			notification.getBody(),
+			senderType,
+			senderProfileImage,
 			notification.getReferenceId(),
 			notification.isRead(),
 			timeFormatter.formatRelativeTime(notification.getCreatedAt())
 		);
 	}
 
-	public Notification createNotification(User user, NotificationType type,
+	public Notification createNotification(User user, StudentCouncil studentCouncil, NotificationType type,
 		String title, String body, Long referenceId) {
 		return Notification.builder()
 			.user(user)
+			.studentCouncil(studentCouncil)
 			.type(type)
 			.title(title)
 			.body(body)

--- a/src/main/java/com/campus/campus/domain/notification/application/service/NotificationService.java
+++ b/src/main/java/com/campus/campus/domain/notification/application/service/NotificationService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.councilpost.application.dto.request.CouncilPostCreatedEvent;
 import com.campus.campus.domain.notification.application.dto.CursorResponse;
 import com.campus.campus.domain.notification.application.dto.NextCursor;
@@ -84,13 +85,16 @@ public class NotificationService {
 	}
 
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
-	public void savePostCreatedNotification(CouncilPostCreatedEvent event, String title, String body) {
+	public void savePostCreatedNotification(CouncilPostCreatedEvent event, String title, String body,
+		StudentCouncil studentCouncil
+	) {
 
 		List<User> targetUsers = findUsersByTopic(event.topic());
 
 		List<Notification> notifications = targetUsers.stream()
 			.map(user -> notificationMapper.createNotification(
 				user,
+				studentCouncil,
 				NotificationType.COUNCIL_POST_CREATED,
 				title,
 				body,
@@ -106,7 +110,7 @@ public class NotificationService {
 		User user = userRepository.findByIdAndDeletedAtIsNull(userId)
 			.orElseThrow(UserNotFoundException::new);
 
-		Notification notification = notificationMapper.createNotification(user, NotificationType.REWARD_GRANTED, title,
+		Notification notification = notificationMapper.createNotification(user, null, NotificationType.REWARD_GRANTED, title,
 			body, null);
 
 		notificationRepository.save(notification);
@@ -124,6 +128,7 @@ public class NotificationService {
 
 		Notification notification = notificationMapper.createNotification(
 			user,
+			null,
 			NotificationType.SYSTEM_NOTICE,
 			title,
 			body,

--- a/src/main/java/com/campus/campus/domain/notification/domain/entity/SenderType.java
+++ b/src/main/java/com/campus/campus/domain/notification/domain/entity/SenderType.java
@@ -1,0 +1,6 @@
+package com.campus.campus.domain.notification.domain.entity;
+
+public enum SenderType {
+	STUDENT_COUNCIL,
+	SYSTEM
+}


### PR DESCRIPTION
## 🔀 변경 내용
-  알림 조회 시, 학생회 프로필 이미지 추가

## ✅ 작업 항목
- [x] event 발행 메서드에 writer 객체 추가
- [x] 학생회 프로필 이미지 조인하여 반환
- [x] 테스트 완료 여부

## 📸 스크린샷 (선택)

<img width="408" height="299" alt="image" src="https://github.com/user-attachments/assets/edb79c4b-14c2-4f78-b5f3-e16c4824c9c4" />

## 📎 참고 이슈
관련 이슈 번호 #126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 알림에 발신자 유형(학생회 또는 시스템) 표시 추가
  * 알림에 발신자 프로필 이미지(URL) 표시 추가
  * 학생회에서 생성된 게시물 알림에 학생회 정보가 반영되어 표시 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->