### PR TITLE
Feat/#126 학생회 알림 조회 시, 학생회 타입 응답 추가

### DIFF
--- a/src/main/java/com/campus/campus/domain/notification/application/dto/NotificationResponse.java
+++ b/src/main/java/com/campus/campus/domain/notification/application/dto/NotificationResponse.java
@@ -1,5 +1,6 @@
 package com.campus.campus.domain.notification.application.dto;
 
+import com.campus.campus.domain.council.domain.entity.CouncilType;
 import com.campus.campus.domain.notification.domain.entity.NotificationType;
 import com.campus.campus.domain.notification.domain.entity.SenderType;
 
@@ -20,6 +21,9 @@ public record NotificationResponse(
 
 	@Schema(description = "보낸 주체 타입", example = "STUDENT_COUNCIL")
 	SenderType senderType,
+
+	@Schema(description = "학생회 타입", example = "MAJOR_COUNCIL")
+	CouncilType councilType,
 
 	@Schema(description = "보낸 주체 프로필 이미지 URL", example = "https://cdn.example.com/council/profile.png")
 	String profileImageUrl,

--- a/src/main/java/com/campus/campus/domain/notification/application/mapper/NotificationMapper.java
+++ b/src/main/java/com/campus/campus/domain/notification/application/mapper/NotificationMapper.java
@@ -1,9 +1,8 @@
 package com.campus.campus.domain.notification.application.mapper;
 
-import java.util.Optional;
-
 import org.springframework.stereotype.Component;
 
+import com.campus.campus.domain.council.domain.entity.CouncilType;
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.notification.application.dto.NotificationResponse;
 import com.campus.campus.domain.notification.domain.entity.Notification;
@@ -24,13 +23,16 @@ public class NotificationMapper {
 
 		String senderProfileImage;
 		SenderType senderType;
+		CouncilType councilType;
 
 		if (notification.getStudentCouncil() != null) {
 			senderType = SenderType.STUDENT_COUNCIL;
 			senderProfileImage = notification.getStudentCouncil().getCouncilProfileImageUrl();
+			councilType = notification.getStudentCouncil().getCouncilType();
 		} else {
 			senderType = SenderType.SYSTEM;
 			senderProfileImage = null;
+			councilType = null;
 		}
 
 		return new NotificationResponse(
@@ -39,6 +41,7 @@ public class NotificationMapper {
 			notification.getTitle(),
 			notification.getBody(),
 			senderType,
+			councilType,
 			senderProfileImage,
 			notification.getReferenceId(),
 			notification.isRead(),


### PR DESCRIPTION
## 🔀 변경 내용
- 학생회 알림 조회 시에 학생회 타입을 응답에 추가했습니다.

## ✅ 작업 항목
- [x] notificationMapper -> 학생회 타입 조회
- [x] notificationResponse -> 학생회 타입 응답 추가
- [x] 테스트 완료 여부

## 📸 스크린샷 (선택)
<img width="461" height="319" alt="image" src="https://github.com/user-attachments/assets/638f5ff3-1cbe-43f3-998e-a23bf6c9cd6f" />

## 📎 참고 이슈
관련 이슈 번호ㅍ#126

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 알림 응답에 학생회 타입 정보 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->