### PR TITLE
feat/#126: 관심 장소 조회 시, 비제휴매장 이미지, 평점 응답 추가

### DIFF
--- a/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
+++ b/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
@@ -365,6 +365,20 @@ public class PlaceService {
 
 		Map<Long, Double> averageStarMap = reviewService.getAverageListOfStars(placeIds);
 
+		Set<Long> nonPartnershipPlaceIds = pageContent.stream()
+			.map(LikedPlace::getPlace)
+			.filter(place -> !place.isPartnership())
+			.map(Place::getPlaceId)
+			.collect(Collectors.toSet());
+
+		Map<Long, String> reviewImageMap = nonPartnershipPlaceIds.isEmpty()
+			? Collections.emptyMap()
+			: reviewImageRepository.findOldestImageUrlsByPlaceIds(nonPartnershipPlaceIds).stream()
+			.collect(Collectors.toMap(
+				obj -> (Long) obj[0],
+				obj -> (String) obj[1]
+			));
+
 		LocalDateTime now = LocalDateTime.now();
 		Pageable firstOne = PageRequest.of(0, 1);
 
@@ -383,13 +397,11 @@ public class PlaceService {
 					distanceMeter = Math.round(rawDistance * 100.0) / 100.0;
 				}
 
-				Double averageStar = null;
+				Double averageStar = averageStarMap.getOrDefault(place.getPlaceId(), 0.0);
 				String partnershipTitle = null;
 				List<String> imageUrls = List.of();
 
 				if (place.isPartnership()) {
-					averageStar = averageStarMap.getOrDefault(place.getPlaceId(), 0.0);
-
 					List<StudentCouncilPost> activePosts =
 						studentCouncilPostRepository.findActiveByPlaceAndUserScope(
 							place,
@@ -412,6 +424,9 @@ public class PlaceService {
 							.map(PostImage::getImageUrl)
 							.toList();
 					}
+				} else {
+					String reviewImageUrl = reviewImageMap.get(place.getPlaceId());
+					imageUrls = reviewImageUrl != null ? List.of(reviewImageUrl) : List.of();
 				}
 
 				return placeMapper.toLikedPlaceDetailResponse(


### PR DESCRIPTION
## 🔀 변경 내용
- 관심 장소 조회 시 이미지 평점 응답 추가

## ✅ 작업 항목
- [ ] 작업 1
- [ ] 작업 2
- [ ] 테스트 완료 여부

## 📸 스크린샷 (선택)
<img width="491" height="368" alt="image" src="https://github.com/user-attachments/assets/7258a3e4-ea3d-4d27-bcca-37df37348116" />

## 📎 참고 이슈
관련 이슈 번호#123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 찜한 장소 목록에서 비파트너십 장소의 평균 평점이 이제 올바르게 표시됩니다.
* 비파트너십 장소의 리뷰 이미지가 찜한 장소 목록에 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->