### PR TITLE
[FIX] 학생회 조회 중복 결과 에러 수정 (#133)

### DIFF
--- a/src/main/java/com/campus/campus/domain/council/domain/repository/StudentCouncilRepository.java
+++ b/src/main/java/com/campus/campus/domain/council/domain/repository/StudentCouncilRepository.java
@@ -46,13 +46,19 @@ public interface StudentCouncilRepository extends JpaRepository<StudentCouncil, 
 
 	boolean existsByLoginIdAndManagerApprovedIsTrueAndDeletedAtIsNull(String loginId);
 
-	Optional<StudentCouncil> findByMajor_MajorIdAndCouncilTypeAndDeletedAtIsNull(Long majorId, CouncilType councilType);
-
-	Optional<StudentCouncil> findByCollege_CollegeIdAndCouncilTypeAndDeletedAtIsNull(Long collegeId,
-		CouncilType councilType);
-
-	Optional<StudentCouncil> findBySchool_SchoolIdAndCouncilTypeAndDeletedAtIsNull(Long schoolId,
-		CouncilType councilType);
+	@Query("SELECT s FROM StudentCouncil s " +
+		"WHERE s.councilType = :type " +
+		"AND s.managerApproved = true " +
+		"AND s.deletedAt IS NULL " +
+		"AND (" +
+		"  (:type = com.campus.campus.domain.council.domain.entity.CouncilType.MAJOR_COUNCIL AND s.major.majorId = :id) OR "
+		+
+		"  (:type = com.campus.campus.domain.council.domain.entity.CouncilType.COLLEGE_COUNCIL AND s.college.collegeId = :id) OR "
+		+
+		"  (:type = com.campus.campus.domain.council.domain.entity.CouncilType.SCHOOL_COUNCIL AND s.school.schoolId = :id)"
+		+
+		")")
+	Optional<StudentCouncil> findActiveCouncilByTypeAndId(@Param("id") Long id, @Param("type") CouncilType type);
 
 	Optional<StudentCouncil> findByIdAndDeletedAtIsNull(Long councilId);
 

--- a/src/main/java/com/campus/campus/domain/council/domain/repository/StudentCouncilRepository.java
+++ b/src/main/java/com/campus/campus/domain/council/domain/repository/StudentCouncilRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.campus.campus.domain.council.domain.entity.CouncilType;
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 
 public interface StudentCouncilRepository extends JpaRepository<StudentCouncil, Long> {
@@ -45,11 +46,13 @@ public interface StudentCouncilRepository extends JpaRepository<StudentCouncil, 
 
 	boolean existsByLoginIdAndManagerApprovedIsTrueAndDeletedAtIsNull(String loginId);
 
-	Optional<StudentCouncil> findByMajor_MajorIdAndDeletedAtIsNull(Long majorId);
+	Optional<StudentCouncil> findByMajor_MajorIdAndCouncilTypeAndDeletedAtIsNull(Long majorId, CouncilType councilType);
 
-	Optional<StudentCouncil> findByCollege_CollegeIdAndDeletedAtIsNull(Long collegeId);
+	Optional<StudentCouncil> findByCollege_CollegeIdAndCouncilTypeAndDeletedAtIsNull(Long collegeId,
+		CouncilType councilType);
 
-	Optional<StudentCouncil> findBySchool_SchoolIdAndDeletedAtIsNull(Long schoolId);
+	Optional<StudentCouncil> findBySchool_SchoolIdAndCouncilTypeAndDeletedAtIsNull(Long schoolId,
+		CouncilType councilType);
 
 	Optional<StudentCouncil> findByIdAndDeletedAtIsNull(Long councilId);
 

--- a/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
+++ b/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
@@ -375,8 +375,8 @@ public class PlaceService {
 			? Collections.emptyMap()
 			: reviewImageRepository.findOldestImageUrlsByPlaceIds(nonPartnershipPlaceIds).stream()
 			.collect(Collectors.toMap(
-				obj -> (Long) obj[0],
-				obj -> (String) obj[1]
+				obj -> (Long)obj[0],
+				obj -> (String)obj[1]
 			));
 
 		LocalDateTime now = LocalDateTime.now();
@@ -522,21 +522,23 @@ public class PlaceService {
 	private List<StudentCouncil> resolveCouncils(User user) {
 		List<StudentCouncil> councils = new ArrayList<>();
 
+		// 학부 학생회
 		if (user.getMajor() != null) {
-			studentCouncilRepository.findByMajor_MajorIdAndDeletedAtIsNull(
-				user.getMajor().getMajorId()
+			studentCouncilRepository.findByMajor_MajorIdAndCouncilTypeAndDeletedAtIsNull(
+				user.getMajor().getMajorId(), CouncilType.MAJOR_COUNCIL
 			).ifPresent(councils::add);
 		}
 
+		// 단과대 학생회
 		if (user.getCollege() != null) {
-			studentCouncilRepository.findByCollege_CollegeIdAndDeletedAtIsNull(
-				user.getCollege().getCollegeId()
+			studentCouncilRepository.findByCollege_CollegeIdAndCouncilTypeAndDeletedAtIsNull(
+				user.getCollege().getCollegeId(), CouncilType.COLLEGE_COUNCIL
 			).ifPresent(councils::add);
 		}
 
 		if (user.getSchool() != null) {
-			studentCouncilRepository.findBySchool_SchoolIdAndDeletedAtIsNull(
-				user.getSchool().getSchoolId()
+			studentCouncilRepository.findBySchool_SchoolIdAndCouncilTypeAndDeletedAtIsNull(
+				user.getSchool().getSchoolId(), CouncilType.SCHOOL_COUNCIL
 			).ifPresent(councils::add);
 		}
 

--- a/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
+++ b/src/main/java/com/campus/campus/domain/place/application/service/PlaceService.java
@@ -524,20 +524,20 @@ public class PlaceService {
 
 		// 학부 학생회
 		if (user.getMajor() != null) {
-			studentCouncilRepository.findByMajor_MajorIdAndCouncilTypeAndDeletedAtIsNull(
+			studentCouncilRepository.findActiveCouncilByTypeAndId(
 				user.getMajor().getMajorId(), CouncilType.MAJOR_COUNCIL
 			).ifPresent(councils::add);
 		}
 
 		// 단과대 학생회
 		if (user.getCollege() != null) {
-			studentCouncilRepository.findByCollege_CollegeIdAndCouncilTypeAndDeletedAtIsNull(
+			studentCouncilRepository.findActiveCouncilByTypeAndId(
 				user.getCollege().getCollegeId(), CouncilType.COLLEGE_COUNCIL
 			).ifPresent(councils::add);
 		}
 
 		if (user.getSchool() != null) {
-			studentCouncilRepository.findBySchool_SchoolIdAndCouncilTypeAndDeletedAtIsNull(
+			studentCouncilRepository.findActiveCouncilByTypeAndId(
 				user.getSchool().getSchoolId(), CouncilType.SCHOOL_COUNCIL
 			).ifPresent(councils::add);
 		}


### PR DESCRIPTION
## 🔀 변경 내용
- 학생회 조회 로직 유일성 보장: resolveCouncils 메서드에서 사용자의 소속 학생회(학교, 단과대, 학과)를 조회할 때, school_id 중복으로 인해 발생하던 NonUniqueResultException (3001 에러)을 해결했습니다.
- 쿼리 필터링 강화: 단순히 ID로만 조회하던 방식에서 **CouncilType**과 `managerApproved=true`을 함께 조건으로 사용하도록 리포지토리 메서드를 수정하여 정확히 1개의 결과만 반환되도록 보장했습니다.
- JPQL 이용: 기존의 길었던 JPA 메서드 이름을 지양하고, @Query를 활용한 findActiveCouncilByTypeAndId 메서드로 통합하여 가독성과 유지보수성을 높였습니다.

## ✅ 작업 항목
- [x] StudentCouncilRepository 내 CouncilType을 포함한 검색 메서드 추가
- [x] resolveCouncils 서비스 로직 내 계층별 필터링 조건 적용
- [x] 로컬 및 개발 서버 환경에서 제휴 신청(suggestPartnership) 정상 동작 테스트 완료

## 📸 스크린샷 (선택)

## 📎 참고 이슈
Closes #133