### PR TITLE
[FEAT] 학생회 이메일 변경 신청 및 승인 로직 구현 (#135)

### DIFF
--- a/src/main/java/com/campus/campus/domain/council/application/dto/request/StudentCouncilChangeEmailRequest.java
+++ b/src/main/java/com/campus/campus/domain/council/application/dto/request/StudentCouncilChangeEmailRequest.java
@@ -6,6 +6,10 @@ import jakarta.validation.constraints.NotBlank;
 public record StudentCouncilChangeEmailRequest(
 	@Schema(description = "변경할 이메일", example = "campus@campus.ac.kr")
 	@NotBlank
-	String email
+	String email,
+
+	@Schema(description = "당선 사진 url", example = "https://www.election.com.png")
+	@NotBlank
+	String electionImageUrl
 ) {
 }

--- a/src/main/java/com/campus/campus/domain/council/application/service/CouncilService.java
+++ b/src/main/java/com/campus/campus/domain/council/application/service/CouncilService.java
@@ -50,9 +50,10 @@ public class CouncilService {
 		EmailVerification emailVerification = getVerifiedChangeEmail(councilId,
 			studentCouncilChangeEmailRequest.email());
 
-		studentCouncil.changeEmail(studentCouncilChangeEmailRequest.email());
+		studentCouncil.requestEmailChange(studentCouncilChangeEmailRequest.email(),
+			studentCouncilChangeEmailRequest.electionImageUrl());
+		
 		emailVerification.use();
-		studentCouncilRepository.save(studentCouncil);
 	}
 
 	@Transactional

--- a/src/main/java/com/campus/campus/domain/council/domain/entity/StudentCouncil.java
+++ b/src/main/java/com/campus/campus/domain/council/domain/entity/StudentCouncil.java
@@ -47,6 +47,10 @@ public class StudentCouncil extends BaseEntity {
 	@Column(name = "email")
 	private String email;
 
+	// 승인 대기 중인 새 이메일
+	@Column(name = "pending_email")
+	private String pendingEmail;
+
 	@Enumerated(EnumType.STRING)
 	@Column(name = "council_type", nullable = false)
 	private CouncilType councilType;
@@ -94,10 +98,6 @@ public class StudentCouncil extends BaseEntity {
 		this.password = newPassword;
 	}
 
-	public void changeEmail(String newEmail) {
-		this.email = newEmail;
-	}
-
 	public void updateCouncilNickname(String nickname) {
 		this.councilNickname = nickname;
 	}
@@ -116,5 +116,17 @@ public class StudentCouncil extends BaseEntity {
 
 	public void managerApprove() {
 		this.managerApproved = true;
+	}
+
+	public void requestEmailChange(String newEmail, String newElectionImageUrl) {
+		this.pendingEmail = newEmail;
+		this.electionImageUrl = newElectionImageUrl;
+	}
+
+	public void confirmEmailChange() {
+		if (this.pendingEmail != null) {
+			this.email = this.pendingEmail;
+			this.pendingEmail = null;
+		}
 	}
 }

--- a/src/main/java/com/campus/campus/domain/council/domain/repository/StudentCouncilRepository.java
+++ b/src/main/java/com/campus/campus/domain/council/domain/repository/StudentCouncilRepository.java
@@ -64,4 +64,6 @@ public interface StudentCouncilRepository extends JpaRepository<StudentCouncil, 
 
 	List<StudentCouncil> findAllByPendingEmailIsNotNullAndDeletedAtIsNull();
 
+	Optional<StudentCouncil> findByIdAndPendingEmailIsNotNullAndDeletedAtIsNull(Long councilId);
+
 }

--- a/src/main/java/com/campus/campus/domain/council/domain/repository/StudentCouncilRepository.java
+++ b/src/main/java/com/campus/campus/domain/council/domain/repository/StudentCouncilRepository.java
@@ -62,4 +62,6 @@ public interface StudentCouncilRepository extends JpaRepository<StudentCouncil, 
 
 	Optional<StudentCouncil> findByIdAndDeletedAtIsNull(Long councilId);
 
+	List<StudentCouncil> findAllByPendingEmailIsNotNullAndDeletedAtIsNull();
+
 }

--- a/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilController.java
+++ b/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilController.java
@@ -30,12 +30,12 @@ public class StudentCouncilController {
 	private final CouncilService councilService;
 
 	@PatchMapping("/change/email")
-	@Operation(summary = "학생회 이메일 변경")
+	@Operation(summary = "학생회 이메일 변경 요청")
 	public CommonResponse<Void> changeEmail(@CurrentCouncilId Long councilId,
 		@Valid @RequestBody StudentCouncilChangeEmailRequest studentCouncilChangeEmailRequest) {
 		councilService.changeEmail(councilId, studentCouncilChangeEmailRequest);
 
-		return CommonResponse.success(StudentCouncilResponseCode.CHANGE_EMAIL_SUCCESS);
+		return CommonResponse.success(StudentCouncilResponseCode.CHANGE_EMAIL_REQUEST_SUCCESS);
 	}
 
 	@PatchMapping("/change/password")

--- a/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/council/presentation/StudentCouncilResponseCode.java
@@ -16,7 +16,7 @@ public enum StudentCouncilResponseCode implements ResponseCodeInterface {
 	FIND_ID_SUCCESS(200, HttpStatus.OK, "아이디 찾기에 성공했습니다."),
 	VALIDATE_EMAIL_SUCCESS(200, HttpStatus.OK, "이메일 검증에 성공했습니다."),
 	FIND_PASSWORD_SUCCESS(200, HttpStatus.OK, "비밀번호 재설정에 성공했습니다."),
-	CHANGE_EMAIL_SUCCESS(200, HttpStatus.OK, "이메일 변경에 성공했습니다."),
+	CHANGE_EMAIL_REQUEST_SUCCESS(200, HttpStatus.OK, "이메일 변경 요청에 성공했습니다."),
 	CHANGE_PASSWORD_SUCCESS(200, HttpStatus.OK, "비밀번호 변경에 성공했습니다."),
 	CHANGE_NICKNAME_SUCCESS(200, HttpStatus.OK, "학생회 닉네임 변경에 성공했습니다."),
 	CHANGE_PROFILE_IMAGE_SUCCESS(200, HttpStatus.OK, "학생회 프로필 이미지 변경에 성공했습니다."),

--- a/src/main/java/com/campus/campus/domain/manager/application/dto/response/StudentCouncilPendingEmailResponse.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/dto/response/StudentCouncilPendingEmailResponse.java
@@ -1,0 +1,10 @@
+package com.campus.campus.domain.manager.application.dto.response;
+
+public record StudentCouncilPendingEmailResponse(
+	Long councilId,
+	String councilName,
+	String currentEmail,
+	String pendingEmail,
+	String electionImageUrl
+) {
+}

--- a/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
@@ -11,6 +11,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.campus.campus.domain.council.application.exception.EmailAlreadyExistsException;
 import com.campus.campus.domain.council.application.exception.StudentCouncilNotFoundException;
 import com.campus.campus.domain.council.domain.entity.StudentCouncil;
 import com.campus.campus.domain.council.domain.repository.StudentCouncilRepository;
@@ -144,6 +145,10 @@ public class ManagerService {
 	public void approveEmailChange(Long councilId) {
 		StudentCouncil studentCouncil = studentCouncilRepository.findById(councilId)
 			.orElseThrow(StudentCouncilNotFoundException::new);
+
+		if (studentCouncilRepository.existsByEmail(studentCouncil.getPendingEmail())) {
+			throw new EmailAlreadyExistsException();
+		}
 
 		studentCouncil.confirmEmailChange();
 

--- a/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
@@ -143,7 +143,8 @@ public class ManagerService {
 
 	@Transactional
 	public void approveEmailChange(Long councilId) {
-		StudentCouncil studentCouncil = studentCouncilRepository.findById(councilId)
+		StudentCouncil studentCouncil = studentCouncilRepository.
+			findByIdAndPendingEmailIsNotNullAndDeletedAtIsNull(councilId)
 			.orElseThrow(StudentCouncilNotFoundException::new);
 
 		if (studentCouncilRepository.existsByEmail(studentCouncil.getPendingEmail())) {

--- a/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
+++ b/src/main/java/com/campus/campus/domain/manager/application/service/ManagerService.java
@@ -30,6 +30,7 @@ import com.campus.campus.domain.manager.application.dto.response.CertifyRequestC
 import com.campus.campus.domain.manager.application.dto.response.CouncilApproveOrDenyResponse;
 import com.campus.campus.domain.manager.application.dto.response.ManagerLoginResponse;
 import com.campus.campus.domain.manager.application.dto.response.StampRewardNeededUserListResponse;
+import com.campus.campus.domain.manager.application.dto.response.StudentCouncilPendingEmailResponse;
 import com.campus.campus.domain.manager.application.exception.ManagerNotFoundException;
 import com.campus.campus.domain.manager.application.exception.PasswordNotCorrectException;
 import com.campus.campus.domain.manager.application.mapper.ManagerMapper;
@@ -124,6 +125,29 @@ public class ManagerService {
 			.orElseThrow(StudentCouncilNotFoundException::new);
 
 		return managerMapper.toCertifyRequestCouncilResponse(studentCouncil);
+	}
+
+	public List<StudentCouncilPendingEmailResponse> getPendingEmailChangeRequests() {
+		return studentCouncilRepository.findAllByPendingEmailIsNotNullAndDeletedAtIsNull()
+			.stream()
+			.map(council -> new StudentCouncilPendingEmailResponse(
+				council.getId(),
+				council.getCouncilName(),
+				council.getEmail(),
+				council.getPendingEmail(),
+				council.getElectionImageUrl()
+			))
+			.toList();
+	}
+
+	@Transactional
+	public void approveEmailChange(Long councilId) {
+		StudentCouncil studentCouncil = studentCouncilRepository.findById(councilId)
+			.orElseThrow(StudentCouncilNotFoundException::new);
+
+		studentCouncil.confirmEmailChange();
+
+		studentCouncilRepository.save(studentCouncil);
 	}
 
 	public List<StampRewardNeededUserListResponse> getStampRewardNeededUserList() {

--- a/src/main/java/com/campus/campus/domain/manager/presentation/ManagerController.java
+++ b/src/main/java/com/campus/campus/domain/manager/presentation/ManagerController.java
@@ -23,6 +23,7 @@ import com.campus.campus.domain.manager.application.dto.response.CertifyRequestC
 import com.campus.campus.domain.manager.application.dto.response.CouncilApproveOrDenyResponse;
 import com.campus.campus.domain.manager.application.dto.response.ManagerLoginResponse;
 import com.campus.campus.domain.manager.application.dto.response.StampRewardNeededUserListResponse;
+import com.campus.campus.domain.manager.application.dto.response.StudentCouncilPendingEmailResponse;
 import com.campus.campus.domain.manager.application.service.ManagerService;
 import com.campus.campus.global.common.response.CommonResponse;
 
@@ -73,6 +74,22 @@ public class ManagerController {
 		List<CertifyRequestCouncilListResponse> responses = managerService.getCertifyRequestCouncils();
 
 		return CommonResponse.success(ManagerResponseCode.CERTIFY_REQUEST_LIST_SUCCESS, responses);
+	}
+
+	@GetMapping("/councils/pending-emails")
+	@PreAuthorize("hasRole('MANAGER')")
+	@Operation(summary = "학생회 이메일 변경 승인 대기 목록 조회")
+	public CommonResponse<List<StudentCouncilPendingEmailResponse>> getPendingEmailChangeRequest() {
+		List<StudentCouncilPendingEmailResponse> responses = managerService.getPendingEmailChangeRequests();
+		return CommonResponse.success(ManagerResponseCode.COUNCIL_PENDING_EMAIL_REQUEST_LIST_SUCCESS, responses);
+	}
+
+	@PatchMapping("/approve/council/{councilId}/email")
+	@PreAuthorize("hasRole('MANAGER')")
+	@Operation(summary = "학생회 이메일 변경 최종 승인")
+	public CommonResponse<Void> approveEmailChange(@PathVariable Long councilId) {
+		managerService.approveEmailChange(councilId);
+		return CommonResponse.success(ManagerResponseCode.COUNCIL_EMAIL_APPROVE_SUCCESS, null);
 	}
 
 	@GetMapping("/rewards/necessary-users")

--- a/src/main/java/com/campus/campus/domain/manager/presentation/ManagerResponseCode.java
+++ b/src/main/java/com/campus/campus/domain/manager/presentation/ManagerResponseCode.java
@@ -14,6 +14,8 @@ public enum ManagerResponseCode implements ResponseCodeInterface {
 	COUNCIL_APPROVE_OR_DENY_SUCCESS(200, HttpStatus.OK, "학생회 승인 혹은 거부 및 메일 전송에 성공했습니다."),
 	CERTIFY_REQUEST_LIST_SUCCESS(200, HttpStatus.OK, "학생회 인증 요청 목록 조회에 성공했습니다."),
 	CERTIFY_REQUEST_ELECTION_IMAGE_SUCCESS(200, HttpStatus.OK, "해당 학생회 인증 요청 당선 사진 조회에 성공했습니다."),
+	COUNCIL_PENDING_EMAIL_REQUEST_LIST_SUCCESS(200, HttpStatus.OK, "학생회 이메일 변경 요청 목록 조회에 성공했습니다."),
+	COUNCIL_EMAIL_APPROVE_SUCCESS(200, HttpStatus.OK, "해당 학생회의 이메일 변경 요청이 승인되었습니다."),
 	REWARD_NEEDED_USER_LIST_SUCCESS(200, HttpStatus.OK, "스탬프 보상이 필요한 유저 목록 조회에 성공했습니다."),
 	GRANT_REWARD_SUCCESS(200, HttpStatus.OK, "스탬프 보상 지급에 성공했습니다."),
 	INQUIRY_LIST_SUCCESS(200, HttpStatus.OK, "문의 내역 조회에 성공했습니다."),


### PR DESCRIPTION
## 🔀 변경 내용
- 학생회 이메일 변경 신청 로직 구현: 학생회가 새로운 이메일과 Object Storage에 업로드한 당선 사진 URL을 함께 전달하여 변경을 요청하는 기능을 추가했습니다.
- 승인 대기(Pending) 시스템 도입: 보안 및 신뢰성 확보를 위해 이메일이 즉시 변경되지 않고, pending_email 필드에 임시 저장된 후 관리자의 확인을 거치도록 설계했습니다.
- 관리자 전용 승인/조회 API: 관리자가 승인 대기 중인 학생회 목록과 당선 사진을 확인하고, 최종적으로 이메일 변경을 확정(Confirm)하는 기능을 구현했습니다.
- 인증 및 보안 강화: CHANGE_EMAIL 타입의 이메일 인증이 완료된 경우에만 요청이 가능하도록 검증 로직을 적용했습니다.

## ✅ 작업 항목
- [x] StudentCouncil 엔티티 내 pendingEmail 필드 추가 및 비즈니스 로직(requestEmailChange, confirmEmailChange) 구현
- [x] 학생회 측 이메일 변경 신청 API 개발 및 인증 코드 연동
- [x] 관리자 측 승인 대기 목록 조회 API 개발
- [x] 관리자 측 이메일 변경 최종 승인 API 개발
- [x] ManagerResponseCode 및 StudentCouncilResponseCode 내 관련 응답 코드 정의

## 📸 스크린샷 (선택)

## 📎 참고 이슈
Closes #135 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 학생회 이메일 변경이 즉시 반영 대신 승인 대기 방식으로 전환되었습니다.
  * 이메일 변경 요청 시 선거 이미지 URL이 필수로 추가되었습니다.
  * 관리자가 대기 중인 이메일 변경 요청 목록을 조회하고 개별 요청을 승인할 수 있는 관리자 API가 추가되었습니다.

* **응답 메시지 변경**
  * 이메일 변경 성공 메시지가 “변경 요청 성공” 형태로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->