### PR TITLE
[FIX] 제휴 업체 리스트 조회 시 실제 리뷰 개수 반영 (#139)

### DIFF
--- a/src/main/java/com/campus/campus/domain/place/application/service/PartnershipPlaceService.java
+++ b/src/main/java/com/campus/campus/domain/place/application/service/PartnershipPlaceService.java
@@ -103,6 +103,8 @@ public class PartnershipPlaceService {
 			.map(post -> post.getPlace().getPlaceId())
 			.collect(Collectors.toSet());
 
+		Map<Long, Long> totalReviewCountMap = reviewService.getReviewCounts(placeIds);
+
 		Map<Long, Double> averageStarMap =
 			reviewService.getAverageListOfStars(placeIds);
 
@@ -131,6 +133,8 @@ public class PartnershipPlaceService {
 
 				double averageStar = averageStarMap.getOrDefault(post.getPlace().getPlaceId(), 0.0);
 
+				int totalReviewCount = totalReviewCountMap.getOrDefault(post.getPlace().getPlaceId(), 0L).intValue();
+
 				List<SimpleReviewResponse> reviews = reviewService.getReviewSummaryList(post.getPlace().getPlaceId());
 
 				return placeMapper.toPartnershipResponse(
@@ -142,7 +146,7 @@ public class PartnershipPlaceService {
 					rounded,
 					averageStar,
 					reviews,
-					size
+					totalReviewCount
 				);
 			})
 			.toList();

--- a/src/main/java/com/campus/campus/domain/review/application/service/ReviewService.java
+++ b/src/main/java/com/campus/campus/domain/review/application/service/ReviewService.java
@@ -23,8 +23,8 @@ import com.campus.campus.domain.councilpost.application.exception.PlaceInfoNotFo
 import com.campus.campus.domain.councilpost.application.exception.PostImageLimitExceededException;
 import com.campus.campus.domain.councilpost.domain.entity.StudentCouncilPost;
 import com.campus.campus.domain.councilpost.domain.repository.StudentCouncilPostRepository;
-import com.campus.campus.domain.place.application.mapper.PlaceMapper;
 import com.campus.campus.domain.place.application.exception.PlaceCreationException;
+import com.campus.campus.domain.place.application.mapper.PlaceMapper;
 import com.campus.campus.domain.place.domain.entity.Place;
 import com.campus.campus.domain.place.domain.repository.LikedPlacesRepository;
 import com.campus.campus.domain.place.domain.repository.PlaceRepository;
@@ -399,7 +399,7 @@ public class ReviewService {
 		}
 
 		return partnerships.stream()
-			.map(post->{
+			.map(post -> {
 				double distance = GeoUtil.distanceMeter(
 					lat, lng,
 					post.getPlace().getCoordinate().latitude(),
@@ -441,6 +441,27 @@ public class ReviewService {
 		return reviewPage.map(review ->
 			reviewMapper.toMyReviewResponse(review, imageMap.get(review.getId()))
 		);
+	}
+
+	@Transactional(readOnly = true)
+	public Map<Long, Long> getReviewCounts(Set<Long> placeIds) {
+		if (placeIds == null || placeIds.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		List<Object[]> results = reviewRepository.findReviewCountsByPlaceIds(placeIds);
+
+		Map<Long, Long> countMap = results.stream()
+			.collect(Collectors.toMap(
+				res -> (Long)res[0],
+				res -> (Long)res[1]
+			));
+
+		for (Long placeId : placeIds) {
+			countMap.putIfAbsent(placeId, 0L);
+		}
+
+		return countMap;
 	}
 
 	private ReviewCreateResponse createReviewResponse(Review review, Place place, User user, List<String> imageUrls) {

--- a/src/main/java/com/campus/campus/domain/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/campus/campus/domain/review/domain/repository/ReviewRepository.java
@@ -73,11 +73,14 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 	List<Review> findTop3ByPlace_PlaceIdOrderByCreatedAtDesc(Long placeId);
 
 	@Query(value = """
-        SELECT r FROM Review r
-        JOIN FETCH r.place
-        WHERE r.user.id = :userId
-        ORDER BY r.createdAt DESC
-        """,
+		SELECT r FROM Review r
+		JOIN FETCH r.place
+		WHERE r.user.id = :userId
+		ORDER BY r.createdAt DESC
+		""",
 		countQuery = "SELECT count(r) FROM Review r WHERE r.user.id = :userId")
 	Page<Review> findByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId, Pageable pageable);
+
+	@Query("SELECT r.place.placeId, COUNT(r) FROM Review r WHERE r.place.placeId IN :placeIds GROUP BY r.place.placeId")
+	List<Object[]> findReviewCountsByPlaceIds(@Param("placeIds") Set<Long> placeIds);
 }


### PR DESCRIPTION
## 🔀 변경 내용
- 리뷰 개수 매핑 오류 수정: 제휴 장소 리스트 조회 시, reviewSize 필드에 실제 리뷰 총 개수가 아닌 페이징 파라미터(size)가 매핑되던 버그를 수정했습니다.
- 데이터 정합성 확보: ReviewService에 getReviewCounts 메서드를 추가하여 장소별 실제 리뷰 카운트를 Map 형태로 관리하고, 이를 DTO 매핑 시 활용하도록 변경했습니다.

## ✅ 작업 항목
- [x] ReviewRepository 내 IN 절을 활용한 장소별 리뷰 카운트 쿼리 구현
- [x] ReviewService 내 Map<Long, Long>을 반환하는 일괄 조회 로직 추가
- [x] getPartnershipPlaces 서비스 로직에서 실제 리뷰 개수(totalReviewCount) 매핑 적용
- [x] Swagger를 통해 페이징 size와 상관없이 실제 리뷰 개수가 출력되는지 테스트 완료

## 📸 스크린샷 (선택)

## 📎 참고 이슈
Closes #139 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 제휴처 장소 조회 시 각 장소의 리뷰 수를 함께 표시하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->