### PR TITLE
feat/#147: add nickname validation and per-school uniqueness check

### DIFF
--- a/src/main/java/com/campus/campus/domain/user/application/dto/request/CampusNicknameUpdateRequest.java
+++ b/src/main/java/com/campus/campus/domain/user/application/dto/request/CampusNicknameUpdateRequest.java
@@ -1,11 +1,14 @@
 package com.campus.campus.domain.user.application.dto.request;
 
+import com.campus.campus.global.annotation.ValidNickname;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 public record CampusNicknameUpdateRequest(
-	@Schema(description = "서비스 내 닉네임", example = "캠퍼스러버")
+	@Schema(description = "서비스 내 닉네임 (한글/영문/숫자, 2~15자)", example = "캠퍼스러버")
 	@NotBlank
+	@ValidNickname
 	String campusNickname
 ) {
 }

--- a/src/main/java/com/campus/campus/domain/user/application/exception/ErrorCode.java
+++ b/src/main/java/com/campus/campus/domain/user/application/exception/ErrorCode.java
@@ -14,7 +14,7 @@ public enum ErrorCode implements ErrorCodeInterface {
 	USER_NOT_FIRST_LOGIN(2101, HttpStatus.BAD_REQUEST, "최초 로그인한 사용자가 아닙니다."),
 	NICKNAME_NOT_MATCH(2102, HttpStatus.BAD_REQUEST, "닉네임이 일치하지 않습니다."),
 	USER_SIGNUP_FORBIDDEN_NOW(2103, HttpStatus.FORBIDDEN, "현재 회원가입할 수 없는 계정입니다."),
-	NICKNAME_ALREADY_EXISTS(2104, HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
+	NICKNAME_ALREADY_EXISTS(2104, HttpStatus.CONFLICT, "이미 사용 중인 닉네임이예요."),
 	ACADEMIC_INFO_CANNOT_CHANGE(2105, HttpStatus.BAD_REQUEST, "학적 정보는 6개월에 한번만 변경 가능합니다."),
 	CAU_SCHOOL_ONLY(2106, HttpStatus.BAD_REQUEST, "중앙대학교 학생만 가입할 수 있습니다."),
 	INQUIRY_NOT_FOUND(2107, HttpStatus.NOT_FOUND, "존재하지 않는 문의입니다."),

--- a/src/main/java/com/campus/campus/domain/user/application/service/UserService.java
+++ b/src/main/java/com/campus/campus/domain/user/application/service/UserService.java
@@ -78,7 +78,9 @@ public class UserService {
 		User user = userRepository.findByIdAndDeletedAtIsNull(userId)
 			.orElseThrow(UserNotFoundException::new);
 
-		if (userRepository.existsByCampusNicknameAndIdNot(nicknameUpdateRequest.campusNickname(), userId)) {
+		Long schoolId = user.getSchool().getSchoolId();
+		if (userRepository.existsByCampusNicknameAndSchool_SchoolIdAndIdNot(
+			nicknameUpdateRequest.campusNickname(), schoolId, userId)) {
 			throw new NicknameAlreadyExistsException();
 		}
 

--- a/src/main/java/com/campus/campus/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/campus/campus/domain/user/domain/repository/UserRepository.java
@@ -21,6 +21,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	boolean existsByCampusNicknameAndIdNot(String campusNickname, Long userId);
 
+	boolean existsByCampusNicknameAndSchool_SchoolIdAndIdNot(String campusNickname, Long schoolId, Long userId);
+
 	List<User> findAllByDeletedAtIsNotNullAndDeletedAtBefore(LocalDateTime softDeleteDate);
 
 	@Query("""

--- a/src/main/java/com/campus/campus/global/annotation/NicknameValidator.java
+++ b/src/main/java/com/campus/campus/global/annotation/NicknameValidator.java
@@ -1,0 +1,19 @@
+package com.campus.campus.global.annotation;
+
+import java.util.regex.Pattern;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class NicknameValidator implements ConstraintValidator<ValidNickname, String> {
+
+	private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[가-힣a-zA-Z0-9]{2,15}$");
+
+	@Override
+	public boolean isValid(String nickname, ConstraintValidatorContext context) {
+		if (nickname == null) {
+			return true;
+		}
+		return NICKNAME_PATTERN.matcher(nickname).matches();
+	}
+}

--- a/src/main/java/com/campus/campus/global/annotation/ValidNickname.java
+++ b/src/main/java/com/campus/campus/global/annotation/ValidNickname.java
@@ -1,0 +1,20 @@
+package com.campus.campus.global.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+@Documented
+@Constraint(validatedBy = NicknameValidator.class)
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidNickname {
+	String message() default "닉네임은 한글, 영문, 숫자만 사용하여 2자 이상 15자 이하로 입력해주세요.";
+	Class<?>[] groups() default {};
+	Class<? extends Payload>[] payload() default {};
+}


### PR DESCRIPTION
## 🔀 변경 내용
- 어떤 기능을 구현하거나 수정했는지 간단히 요약해주세요.

- `@ValidNickname` 신규: 한글/영문/숫자만 사용, 2~15자
- `PATCH /users/change/nickname` 중복 체크를 전역 → **학교당 1개**로 변경
- 중복 시 에러 메시지 "이미 사용 중인 닉네임이예요."로 통일
- banned-nicknames.txt 통한 데모용으로 비속어 방지

## ✅ 작업 항목
- [ ] 작업 1
- [ ] 작업 2
- [ ] 테스트 완료 여부

## 📸 스크린샷 (선택)

## 📎 참고 이슈
관련 이슈 번호#123